### PR TITLE
Port v0.6 patches to current upstream kernel

### DIFF
--- a/patches/v1.0/0000-cover-letter.patch
+++ b/patches/v1.0/0000-cover-letter.patch
@@ -1,0 +1,151 @@
+From 0f3be98299c1331dd6a8d1fb0ad7bf94f18f2ebe Mon Sep 17 00:00:00 2001
+From: Wentao Zhang <wentaoz5@illinois.edu>
+Date: Thu, 18 Jul 2024 13:14:06 -0500
+Subject: [RFC PATCH 0/3] Enable measuring the kernel's Source-based Code Coverage and MC/DC with Clang
+
+This patch series adds support for building x86-64 kernels with Clang's Source-
+based Code Coverage and measuring modified condition/decision coverage (MC/DC).
+
+The newly added kernel/llvm-cov/ directory complements the existing gcov
+implementation. gcov works at a lower level and may better reflect the actual
+execution of object code. However, it lacks the necessary information to connect
+coverage measurement back to source code locations and gcov reports are
+sometimes confusing. With a nonzero optimization level (which is the default
+when building the kernel), it's even harder to rebuild the mapping between
+coverage reports and source code. In the following example from
+drivers/firmware/dmi_scan.c, an expression with four leaf conditions are
+reported to have six branch outcomes, which is not ideally informative in many
+use cases.
+
+        5: 1068:	if (s == e || *e != '/' || !month || month > 12) {
+branch  0 taken 5 (fallthrough)
+branch  1 taken 0
+branch  2 taken 5 (fallthrough)
+branch  3 taken 0
+branch  4 taken 0 (fallthrough)
+branch  5 taken 5
+
+On the other hand, Clang's Source-based Code Coverage [1] does instrumentation
+at the compiler frontend and maintains accurate mapping from coverage measure to
+source code locations. The generated reports can reflect exactly how the code is
+written regardless of optimization and can present advanced metrics like branch
+coverage and MC/DC in a more human-friendly way. Coverage report for the same
+snippet by llvm-cov would look like the below:
+
+ 1068|      5|	if (s == e || *e != '/' || !month || month > 12) {
+  ------------------
+  |  Branch (1068:6): [True: 0, False: 5]
+  |  Branch (1068:16): [True: 0, False: 5]
+  |  Branch (1068:29): [True: 0, False: 5]
+  |  Branch (1068:39): [True: 0, False: 5]
+  ------------------
+
+Clang has also added MC/DC support since its release 18.1.0. MC/DC is a fine-
+grained coverage metric required by many automotive and aviation industrial
+standards for certifying mission-critical software [2]. In the following example
+from arch/x86/events/probe.c, llvm-cov gives the MC/DC measure for the decision
+at line 43.
+
+   43|     12|			if (msr[bit].test && !msr[bit].test(bit, data))
+  ------------------
+  |---> MC/DC Decision Region (43:8) to (43:50)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (43:8)
+  |     Condition C2 --> (43:25)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { T,  F  = F      }
+  |  2 { T,  T  = T      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: covered: (1,2)
+  |  MC/DC Coverage for Decision: 50.00%
+  |
+  ------------------
+   44|      5|				continue;
+
+As the results suggest, during the given span of measurement, only condition C2
+(!msr[bit].test(bit, data)) is covered. That means C2 was evaluated to both true
+and false and in those test vectors C2 affected the decision outcome
+independently. Therefore MC/DC for the shown decision is 1 out of 2 (50.00%).
+
+To do a full kernel measurement, instrument the kernel with LLVM_COV_KERNEL_MCDC
+enabled, run the testsuites, and collect the raw profile data under
+/sys/kernel/debug/llvm-cov/profraw. Such raw profile data can be merged and
+indexed, and used for generating coverage reports in various formats.
+
+  $ cp /sys/kernel/debug/llvm-cov/profraw vmlinux.profraw
+  $ llvm-profdata merge vmlinux.profraw -o vmlinux.profdata
+  $ llvm-cov show --show-mcdc --show-mcdc-summary                              \
+                  --format=text --use-color=false -output-dir=coverage_reports \
+                  -instr-profile vmlinux.profdata vmlinux
+
+The first patch in the series enables Clang's Source-based Code Coverage for the
+kernel. The second patch disables instrumenting the same set of files that were
+skipped by kernel/gcov/ as well. The third patch enables MC/DC instrumentation
+which is built on top of Source-based Code Coverage.
+
+This work reuses a portion of code from a previous effort by Sami Tolvanen et
+al. [3], but we aim for source-based *code coverage* required for high assurance
+(MC/DC) while [3] focused more on performance optimization.
+
+This initial submission is restricted to x86-64. Support for other architectures
+would need a bit more Makefile & linker script modification. Informally we've
+confirmed that arm64 works and more are being tested.
+
+Note that Source-based Code Coverage is Clang-specific and isn't compatible with
+Clang's gcov support in kernel/gcov/. Currently, kernel/gcov/ is not able to
+measure MC/DC without modifying CFLAGS_GCOV and it would face the same issues in
+terms of source correlation as gcov in general does.
+
+Some demo and results can be found in [4]. We will talk about this patch series
+in the Refereed Track of LPC 2024 [5] and would really like to hear the
+community's feedback.
+
+[1] https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
+[2] https://digital-library.theiet.org/content/journals/10.1049/sej.1994.0025
+[3] https://lore.kernel.org/linux-doc/20210407211704.367039-1-morbo@google.com/
+[4] https://github.com/xlab-uiuc/linux-mcdc
+[5] https://lpc.events/event/18/contributions/1718/
+
+Wentao Zhang (3):
+  [RFC PATCH 1/3] llvm-cov: add Clang's Source-based Code Coverage
+    support
+  [RFC PATCH 2/3] kbuild, llvm-cov: disable instrumentation in odd or
+    sensitive code
+  [RFC PATCH 3/3] llvm-cov: add Clang's MC/DC support
+
+ Makefile                              |   9 +
+ arch/Kconfig                          |   1 +
+ arch/x86/Kconfig                      |   1 +
+ arch/x86/boot/Makefile                |   1 +
+ arch/x86/boot/compressed/Makefile     |   1 +
+ arch/x86/entry/vdso/Makefile          |   1 +
+ arch/x86/kernel/vmlinux.lds.S         |   2 +
+ arch/x86/platform/efi/Makefile        |   1 +
+ arch/x86/purgatory/Makefile           |   1 +
+ arch/x86/realmode/rm/Makefile         |   1 +
+ arch/x86/um/vdso/Makefile             |   1 +
+ drivers/firmware/efi/libstub/Makefile |   2 +
+ include/asm-generic/vmlinux.lds.h     |  38 ++++
+ kernel/Makefile                       |   1 +
+ kernel/llvm-cov/Kconfig               |  51 ++++++
+ kernel/llvm-cov/Makefile              |   5 +
+ kernel/llvm-cov/fs.c                  | 253 ++++++++++++++++++++++++++
+ kernel/llvm-cov/llvm-cov.h            | 156 ++++++++++++++++
+ kernel/trace/Makefile                 |   1 +
+ scripts/Makefile.lib                  |  21 +++
+ scripts/Makefile.modfinal             |   1 +
+ scripts/mod/modpost.c                 |   2 +
+ 22 files changed, 551 insertions(+)
+ create mode 100644 kernel/llvm-cov/Kconfig
+ create mode 100644 kernel/llvm-cov/Makefile
+ create mode 100644 kernel/llvm-cov/fs.c
+ create mode 100644 kernel/llvm-cov/llvm-cov.h
+
+--
+2.34.1
+

--- a/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -1,0 +1,661 @@
+From 87f04331a2b7be8d16ce09b41a4911a5a0ee710f Mon Sep 17 00:00:00 2001
+From: Wentao Zhang <wentaoz5@illinois.edu>
+Date: Tue, 13 Aug 2024 01:45:17 +0100
+Subject: [RFC PATCH 1/3] llvm-cov: add Clang's Source-based Code Coverage
+ support
+
+This patch implements the debugfs entries for serializing profiles and
+resetting counters/bitmaps and adds Source-based Code Coverage flags and
+kconfig options.
+
+This work reuses a portion of code from a previous effort by Sami
+Tolvanen et al. [1], specifically its debugfs interface and the
+underlying profile processing, but discards all its PGO-specific parts,
+notably value profiling.  To our end (code coverage, like MC/DC,
+required for high assurance), we do instrumentation at the compiler
+frontend, instead of IR; we care about counters and bitmaps, but not
+value profiling.
+
+[1] https://lore.kernel.org/linux-doc/20210407211704.367039-1-morbo@google.com/
+
+Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
+Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
+---
+ Makefile                          |   3 +
+ arch/Kconfig                      |   1 +
+ arch/x86/Kconfig                  |   1 +
+ arch/x86/kernel/vmlinux.lds.S     |   2 +
+ include/asm-generic/vmlinux.lds.h |  38 +++++
+ kernel/Makefile                   |   1 +
+ kernel/llvm-cov/Kconfig           |  30 ++++
+ kernel/llvm-cov/Makefile          |   5 +
+ kernel/llvm-cov/fs.c              | 253 ++++++++++++++++++++++++++++++
+ kernel/llvm-cov/llvm-cov.h        | 156 ++++++++++++++++++
+ scripts/Makefile.lib              |  10 ++
+ scripts/mod/modpost.c             |   2 +
+ 12 files changed, 502 insertions(+)
+ create mode 100644 kernel/llvm-cov/Kconfig
+ create mode 100644 kernel/llvm-cov/Makefile
+ create mode 100644 kernel/llvm-cov/fs.c
+ create mode 100644 kernel/llvm-cov/llvm-cov.h
+
+diff --git a/Makefile b/Makefile
+index 0a364e34f50b..2ca34d00ea39 100644
+--- a/Makefile
++++ b/Makefile
+@@ -737,6 +737,9 @@ endif # KBUILD_EXTMOD
+ # Defaults to vmlinux, but the arch makefile usually adds further targets
+ all: vmlinux
+ 
++CFLAGS_LLVM_COV := -fprofile-instr-generate -fcoverage-mapping
++export CFLAGS_LLVM_COV
++
+ CFLAGS_GCOV	:= -fprofile-arcs -ftest-coverage
+ ifdef CONFIG_CC_IS_GCC
+ CFLAGS_GCOV	+= -fno-tree-loop-im
+diff --git a/arch/Kconfig b/arch/Kconfig
+index 975dd22a2dbd..0727265f677f 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -1601,6 +1601,7 @@ config ARCH_HAS_KERNEL_FPU_SUPPORT
+ 	  the kernel, as described in Documentation/core-api/floating-point.rst.
+ 
+ source "kernel/gcov/Kconfig"
++source "kernel/llvm-cov/Kconfig"
+ 
+ source "scripts/gcc-plugins/Kconfig"
+ 
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index 007bab9f2a0e..87a793b82bab 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -85,6 +85,7 @@ config X86
+ 	select ARCH_HAS_FORTIFY_SOURCE
+ 	select ARCH_HAS_GCOV_PROFILE_ALL
+ 	select ARCH_HAS_KCOV			if X86_64
++	select ARCH_HAS_LLVM_COV		if X86_64
+ 	select ARCH_HAS_KERNEL_FPU_SUPPORT
+ 	select ARCH_HAS_MEM_ENCRYPT
+ 	select ARCH_HAS_MEMBARRIER_SYNC_CORE
+diff --git a/arch/x86/kernel/vmlinux.lds.S b/arch/x86/kernel/vmlinux.lds.S
+index 6e73403e874f..90433772240a 100644
+--- a/arch/x86/kernel/vmlinux.lds.S
++++ b/arch/x86/kernel/vmlinux.lds.S
+@@ -191,6 +191,8 @@ SECTIONS
+ 
+ 	BUG_TABLE
+ 
++	LLVM_COV_DATA
++
+ 	ORC_UNWIND_TABLE
+ 
+ 	. = ALIGN(PAGE_SIZE);
+diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
+index 1ae44793132a..770ff8469dcd 100644
+--- a/include/asm-generic/vmlinux.lds.h
++++ b/include/asm-generic/vmlinux.lds.h
+@@ -334,6 +334,44 @@
+ #define THERMAL_TABLE(name)
+ #endif
+ 
++#ifdef CONFIG_LLVM_COV_KERNEL
++#define LLVM_COV_DATA							\
++	__llvm_prf_data : AT(ADDR(__llvm_prf_data) - LOAD_OFFSET) {	\
++		__llvm_prf_start = .;					\
++		__llvm_prf_data_start = .;				\
++		*(__llvm_prf_data)					\
++		__llvm_prf_data_end = .;				\
++	}								\
++	__llvm_prf_cnts : AT(ADDR(__llvm_prf_cnts) - LOAD_OFFSET) {	\
++		__llvm_prf_cnts_start = .;				\
++		*(__llvm_prf_cnts)					\
++		__llvm_prf_cnts_end = .;				\
++	}								\
++	__llvm_prf_names : AT(ADDR(__llvm_prf_names) - LOAD_OFFSET) {	\
++		__llvm_prf_names_start = .;				\
++		*(__llvm_prf_names)					\
++		__llvm_prf_names_end = .;				\
++	}								\
++	__llvm_prf_bits : AT(ADDR(__llvm_prf_bits) - LOAD_OFFSET) {	\
++		__llvm_prf_bits_start = .;				\
++		*(__llvm_prf_bits)					\
++		__llvm_prf_bits_end = .;				\
++	}								\
++	__llvm_covfun : AT(ADDR(__llvm_covfun) - LOAD_OFFSET) {		\
++		__llvm_covfun_start = .;				\
++		*(__llvm_covfun)					\
++		__llvm_covfun_end = .;					\
++	}								\
++	__llvm_covmap : AT(ADDR(__llvm_covmap) - LOAD_OFFSET) {		\
++		__llvm_covmap_start = .;				\
++		*(__llvm_covmap)					\
++		__llvm_covmap_end = .;					\
++		__llvm_prf_end = .;					\
++	}
++#else
++#define LLVM_COV_DATA
++#endif
++
+ #define KERNEL_DTB()							\
+ 	STRUCT_ALIGN();							\
+ 	__dtb_start = .;						\
+diff --git a/kernel/Makefile b/kernel/Makefile
+index 3c13240dfc9f..773e6a9ee00a 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -117,6 +117,7 @@ obj-$(CONFIG_HAVE_STATIC_CALL) += static_call.o
+ obj-$(CONFIG_HAVE_STATIC_CALL_INLINE) += static_call_inline.o
+ obj-$(CONFIG_CFI_CLANG) += cfi.o
+ obj-$(CONFIG_NUMA) += numa.o
++obj-$(CONFIG_LLVM_COV_KERNEL) += llvm-cov/
+ 
+ obj-$(CONFIG_PERF_EVENTS) += events/
+ 
+diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
+new file mode 100644
+index 000000000000..b28090ba926b
+--- /dev/null
++++ b/kernel/llvm-cov/Kconfig
+@@ -0,0 +1,30 @@
++# SPDX-License-Identifier: GPL-2.0-only
++menu "Clang's source-based kernel coverage measurement (EXPERIMENTAL)"
++
++config ARCH_HAS_LLVM_COV
++	bool
++
++config LLVM_COV_KERNEL
++	bool "Enable Clang's source-based kernel coverage measurement"
++	depends on DEBUG_FS
++	depends on ARCH_HAS_LLVM_COV
++	depends on CC_IS_CLANG && CLANG_VERSION >= 180000
++	default n
++	help
++	  This option enables Clang's Source-based Code Coverage.
++
++	  If unsure, say N.
++
++	  On a kernel compiled with this option, run your test suites, and
++	  download the raw profile from /sys/kernel/debug/llvm-cov/profraw.
++	  This file can then be converted into the indexed format with
++	  llvm-profdata and used to generate coverage reports with llvm-cov.
++
++	  Note that a kernel compiled with coverage flags will be significantly
++	  larger and run slower.
++
++	  Note that the debugfs filesystem has to be mounted to access the raw
++	  profile.
++
++endmenu
++
+diff --git a/kernel/llvm-cov/Makefile b/kernel/llvm-cov/Makefile
+new file mode 100644
+index 000000000000..a0f45e05f8fb
+--- /dev/null
++++ b/kernel/llvm-cov/Makefile
+@@ -0,0 +1,5 @@
++# SPDX-License-Identifier: GPL-2.0
++GCOV_PROFILE		:= n
++LLVM_COV_PROFILE	:= n
++
++obj-y	+= fs.o
+\ No newline at end of file
+diff --git a/kernel/llvm-cov/fs.c b/kernel/llvm-cov/fs.c
+new file mode 100644
+index 000000000000..917ca50d0496
+--- /dev/null
++++ b/kernel/llvm-cov/fs.c
+@@ -0,0 +1,253 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2019	Sami Tolvanen <samitolvanen@google.com>, Google, Inc.
++ * Copyright (C) 2024	Jinghao Jia   <jinghao7@illinois.edu>,   UIUC
++ * Copyright (C) 2024	Wentao Zhang  <wentaoz5@illinois.edu>,   UIUC
++ *
++ * This software is licensed under the terms of the GNU General Public
++ * License version 2, as published by the Free Software Foundation, and
++ * may be copied, distributed, and modified under those terms.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ */
++
++#define pr_fmt(fmt)	"llvm-cov: " fmt
++
++#include <linux/kernel.h>
++#include <linux/debugfs.h>
++#include <linux/fs.h>
++#include <linux/module.h>
++#include <linux/slab.h>
++#include <linux/vmalloc.h>
++#include <linux/spinlock.h>
++#include "llvm-cov.h"
++
++/*
++ * This lock guards both counter/bitmap reset and serialization of the
++ * raw profile data. Keeping both of these activities separate via locking
++ * ensures that we don't try to serialize data that's being reset.
++ */
++DEFINE_SPINLOCK(llvm_cov_lock);
++
++static struct dentry *directory;
++
++struct llvm_cov_private_data {
++	char *buffer;
++	unsigned long size;
++};
++
++/*
++ * Raw profile data format:
++ * https://llvm.org/docs/InstrProfileFormat.html#raw-profile-format. We will
++ * only populate information that's relevant to basic Source-based Code Coverage
++ * before serialization. Other features like binary IDs, continuous mode,
++ * single-byte mode, value profiling, type profiling etc are not implemented.
++ */
++
++static void llvm_cov_fill_raw_profile_header(void **buffer)
++{
++	struct __llvm_profile_header *header = *(struct __llvm_profile_header **)buffer;
++
++	header->magic = INSTR_PROF_RAW_MAGIC_64;
++	header->version = INSTR_PROF_RAW_VERSION;
++	header->binary_ids_size = 0;
++	header->num_data = __llvm_prf_data_count();
++	header->padding_bytes_before_counters = 0;
++	header->num_counters = __llvm_prf_cnts_count();
++	header->padding_bytes_after_counters =
++		__llvm_prf_get_padding(__llvm_prf_cnts_size());
++	header->num_bitmap_bytes = __llvm_prf_bits_size();
++	header->padding_bytes_after_bitmap_bytes =
++		__llvm_prf_get_padding(__llvm_prf_bits_size());
++	header->names_size = __llvm_prf_names_size();
++	header->counters_delta = (u64)__llvm_prf_cnts_start -
++				 (u64)__llvm_prf_data_start;
++	header->bitmap_delta   = (u64)__llvm_prf_bits_start -
++				 (u64)__llvm_prf_data_start;
++	header->names_delta    = (u64)__llvm_prf_names_start;
++#if defined(CONFIG_CC_IS_CLANG) && CONFIG_CLANG_VERSION >= 190000
++	header->num_v_tables = 0;
++	header->v_names_size = 0;
++#endif
++	header->value_kind_last = IPVK_LAST;
++
++	*buffer += sizeof(*header);
++}
++
++/*
++ * Copy the source into the buffer, incrementing the pointer into buffer in the
++ * process.
++ */
++static void llvm_cov_copy_section_to_buffer(void **buffer, void *src,
++					    unsigned long size)
++{
++	memcpy(*buffer, src, size);
++	*buffer += size;
++}
++
++static unsigned long llvm_cov_get_raw_profile_size(void)
++{
++	return sizeof(struct __llvm_profile_header) +
++	       __llvm_prf_data_size() +
++	       __llvm_prf_cnts_size() +
++	       __llvm_prf_get_padding(__llvm_prf_cnts_size()) +
++	       __llvm_prf_bits_size() +
++	       __llvm_prf_get_padding(__llvm_prf_bits_size()) +
++	       __llvm_prf_names_size() +
++	       __llvm_prf_get_padding(__llvm_prf_names_size());
++}
++
++/*
++ * Serialize in-memory data into a format LLVM tools can understand
++ * (https://llvm.org/docs/InstrProfileFormat.html#raw-profile-format)
++ */
++static int llvm_cov_serialize_raw_profile(struct llvm_cov_private_data *p)
++{
++	int err = 0;
++	void *buffer;
++
++	p->size = llvm_cov_get_raw_profile_size();
++	p->buffer = vzalloc(p->size);
++
++	if (!p->buffer) {
++		err = -ENOMEM;
++		goto out;
++	}
++
++	buffer = p->buffer;
++
++	llvm_cov_fill_raw_profile_header(&buffer);
++	llvm_cov_copy_section_to_buffer(&buffer, __llvm_prf_data_start,
++					__llvm_prf_data_size());
++	llvm_cov_copy_section_to_buffer(&buffer, __llvm_prf_cnts_start,
++					__llvm_prf_cnts_size());
++	buffer += __llvm_prf_get_padding(__llvm_prf_cnts_size());
++	llvm_cov_copy_section_to_buffer(&buffer, __llvm_prf_bits_start,
++					__llvm_prf_bits_size());
++	buffer += __llvm_prf_get_padding(__llvm_prf_bits_size());
++	llvm_cov_copy_section_to_buffer(&buffer, __llvm_prf_names_start,
++					__llvm_prf_names_size());
++	buffer += __llvm_prf_get_padding(__llvm_prf_names_size());
++
++out:
++	return err;
++}
++
++/* open() implementation for llvm-cov data file. */
++static int llvm_cov_open(struct inode *inode, struct file *file)
++{
++	struct llvm_cov_private_data *data;
++	unsigned long flags;
++	int err;
++
++	data = kzalloc(sizeof(*data), GFP_KERNEL);
++	if (!data) {
++		err = -ENOMEM;
++		goto out;
++	}
++
++	flags = llvm_cov_claim_lock();
++
++	err = llvm_cov_serialize_raw_profile(data);
++	if (unlikely(err)) {
++		kfree(data);
++		goto out_unlock;
++	}
++
++	file->private_data = data;
++
++out_unlock:
++	llvm_cov_release_lock(flags);
++out:
++	return err;
++}
++
++/* read() implementation for llvm-cov data file. */
++static ssize_t llvm_cov_read(struct file *file, char __user *buf, size_t count,
++			loff_t *ppos)
++{
++	struct llvm_cov_private_data *data = file->private_data;
++
++	if (!data)
++		return -EBADF;
++
++	return simple_read_from_buffer(buf, count, ppos, data->buffer,
++				       data->size);
++}
++
++/* release() implementation for llvm-cov data file. */
++static int llvm_cov_release(struct inode *inode, struct file *file)
++{
++	struct llvm_cov_private_data *data = file->private_data;
++
++	if (data) {
++		vfree(data->buffer);
++		kfree(data);
++	}
++
++	return 0;
++}
++
++static const struct file_operations llvm_cov_data_fops = {
++	.owner		= THIS_MODULE,
++	.open		= llvm_cov_open,
++	.read		= llvm_cov_read,
++	.llseek		= default_llseek,
++	.release	= llvm_cov_release
++};
++
++/* write() implementation for llvm-cov reset file */
++static ssize_t reset_write(struct file *file, const char __user *addr,
++			   size_t len, loff_t *pos)
++{
++	unsigned long flags;
++
++	flags = llvm_cov_claim_lock();
++	memset(__llvm_prf_cnts_start, 0, __llvm_prf_cnts_size());
++	memset(__llvm_prf_bits_start, 0, __llvm_prf_bits_size());
++	llvm_cov_release_lock(flags);
++
++	return len;
++}
++
++static const struct file_operations llvm_cov_reset_fops = {
++	.owner		= THIS_MODULE,
++	.write		= reset_write,
++	.llseek		= noop_llseek,
++};
++
++/* Create debugfs entries. */
++static int __init llvm_cov_init(void)
++{
++	directory = debugfs_create_dir("llvm-cov", NULL);
++	if (!directory)
++		goto err_remove;
++
++	if (!debugfs_create_file("profraw", 0400, directory, NULL,
++				 &llvm_cov_data_fops))
++		goto err_remove;
++
++	if (!debugfs_create_file("reset", 0200, directory, NULL,
++				 &llvm_cov_reset_fops))
++		goto err_remove;
++
++	return 0;
++
++err_remove:
++	debugfs_remove_recursive(directory);
++	pr_err("initialization failed\n");
++	return -EIO;
++}
++
++/* Remove debugfs entries. */
++static void __exit llvm_cov_exit(void)
++{
++	debugfs_remove_recursive(directory);
++}
++
++module_init(llvm_cov_init);
++module_exit(llvm_cov_exit);
+\ No newline at end of file
+diff --git a/kernel/llvm-cov/llvm-cov.h b/kernel/llvm-cov/llvm-cov.h
+new file mode 100644
+index 000000000000..4a91b3c8ed72
+--- /dev/null
++++ b/kernel/llvm-cov/llvm-cov.h
+@@ -0,0 +1,156 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2019	Sami Tolvanen <samitolvanen@google.com>, Google, Inc.
++ * Copyright (C) 2024	Jinghao Jia   <jinghao7@illinois.edu>,   UIUC
++ * Copyright (C) 2024	Wentao Zhang  <wentaoz5@illinois.edu>,   UIUC
++ *
++ * This software is licensed under the terms of the GNU General Public
++ * License version 2, as published by the Free Software Foundation, and
++ * may be copied, distributed, and modified under those terms.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ */
++
++#ifndef _LLVM_COV_H
++#define _LLVM_COV_H
++
++extern spinlock_t llvm_cov_lock;
++
++static __always_inline unsigned long llvm_cov_claim_lock(void)
++{
++	unsigned long flags;
++
++	spin_lock_irqsave(&llvm_cov_lock, flags);
++
++	return flags;
++}
++
++static __always_inline void llvm_cov_release_lock(unsigned long flags)
++{
++	spin_unlock_irqrestore(&llvm_cov_lock, flags);
++}
++
++/*
++ * Note: These internal LLVM definitions must match the compiler version.
++ * See llvm/include/llvm/ProfileData/InstrProfData.inc in LLVM's source code.
++ */
++
++#define INSTR_PROF_RAW_MAGIC_64		\
++		((u64)255 << 56 |	\
++		 (u64)'l' << 48 |	\
++		 (u64)'p' << 40 |	\
++		 (u64)'r' << 32 |	\
++		 (u64)'o' << 24 |	\
++		 (u64)'f' << 16 |	\
++		 (u64)'r' << 8  |	\
++		 (u64)129)
++
++#if defined(CONFIG_CC_IS_CLANG) && CONFIG_CLANG_VERSION >= 190000
++#define INSTR_PROF_RAW_VERSION		10
++#define INSTR_PROF_DATA_ALIGNMENT	8
++#define IPVK_LAST			2
++#elif defined(CONFIG_CC_IS_CLANG) && CONFIG_CLANG_VERSION >= 180000
++#define INSTR_PROF_RAW_VERSION		9
++#define INSTR_PROF_DATA_ALIGNMENT	8
++#define IPVK_LAST			1
++#endif
++
++/**
++ * struct __llvm_profile_header - represents the raw profile header data
++ * structure. Description of each member can be found here:
++ * https://llvm.org/docs/InstrProfileFormat.html#header.
++ */
++struct __llvm_profile_header {
++	u64 magic;
++	u64 version;
++	u64 binary_ids_size;
++	u64 num_data;
++	u64 padding_bytes_before_counters;
++	u64 num_counters;
++	u64 padding_bytes_after_counters;
++	u64 num_bitmap_bytes;
++	u64 padding_bytes_after_bitmap_bytes;
++	u64 names_size;
++	u64 counters_delta;
++	u64 bitmap_delta;
++	u64 names_delta;
++#if defined(CONFIG_CC_IS_CLANG) && CONFIG_CLANG_VERSION >= 190000
++	u64 num_v_tables;
++	u64 v_names_size;
++#endif
++	u64 value_kind_last;
++};
++
++/**
++ * struct __llvm_profile_data - represents the per-function control structure.
++ * Description of each member can be found here:
++ * https://llvm.org/docs/InstrProfileFormat.html#profile-metadata. To measure
++ * Source-based Code Coverage, the internals of this struct don't matter at run
++ * time. The only purpose of the definition below is to run sizeof() against it
++ * so that we can calculate the "num_data" field in header.
++ */
++struct __llvm_profile_data {
++	const u64 name_ref;
++	const u64 func_hash;
++	const void *counter_ptr;
++	const void *bitmap_ptr;
++	const void *function_pointer;
++	void *values;
++	const u32 num_counters;
++	const u16 num_value_sites[IPVK_LAST + 1];
++	const u32 num_bitmap_bytes;
++} __aligned(INSTR_PROF_DATA_ALIGNMENT);
++
++/* Payload sections */
++
++extern struct __llvm_profile_data __llvm_prf_data_start[];
++extern struct __llvm_profile_data __llvm_prf_data_end[];
++
++extern u64 __llvm_prf_cnts_start[];
++extern u64 __llvm_prf_cnts_end[];
++
++extern char __llvm_prf_names_start[];
++extern char __llvm_prf_names_end[];
++
++extern char __llvm_prf_bits_start[];
++extern char __llvm_prf_bits_end[];
++
++#define __DEFINE_SECTION_SIZE(s)					\
++	static inline unsigned long __llvm_prf_ ## s ## _size(void)	\
++	{								\
++		unsigned long start =					\
++			(unsigned long)__llvm_prf_ ## s ## _start;	\
++		unsigned long end =					\
++			(unsigned long)__llvm_prf_ ## s ## _end;	\
++		return end - start;					\
++	}
++#define __DEFINE_SECTION_COUNT(s)					\
++	static inline unsigned long __llvm_prf_ ## s ## _count(void)	\
++	{								\
++		return __llvm_prf_ ## s ## _size() /			\
++			sizeof(__llvm_prf_ ## s ## _start[0]);		\
++	}
++
++__DEFINE_SECTION_SIZE(data)
++__DEFINE_SECTION_SIZE(cnts)
++__DEFINE_SECTION_SIZE(names)
++__DEFINE_SECTION_SIZE(bits)
++
++__DEFINE_SECTION_COUNT(data)
++__DEFINE_SECTION_COUNT(cnts)
++__DEFINE_SECTION_COUNT(names)
++__DEFINE_SECTION_COUNT(bits)
++
++#undef __DEFINE_SECTION_SIZE
++#undef __DEFINE_SECTION_COUNT
++
++static inline unsigned long __llvm_prf_get_padding(unsigned long size)
++{
++	return 7 & (sizeof(u64) - size % sizeof(u64));
++}
++
++#endif /* _LLVM_COV_H */
+\ No newline at end of file
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index fe3668dc4954..b9ceaee34b28 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -158,6 +158,16 @@ _c_flags += $(if $(patsubst n%,, \
+ 		$(CFLAGS_GCOV))
+ endif
+ 
++#
++# Enable Clang's Source-based Code Coverage flags for a file or directory
++# depending on variables LLVM_COV_PROFILE_obj.o and LLVM_COV_PROFILE.
++#
++ifeq ($(CONFIG_LLVM_COV_KERNEL),y)
++_c_flags += $(if $(patsubst n%,, \
++		$(LLVM_COV_PROFILE_$(basetarget).o)$(LLVM_COV_PROFILE)y), \
++		$(CFLAGS_LLVM_COV))
++endif
++
+ #
+ # Enable address sanitizer flags for kernel except some files or directories
+ # we don't want to check (depends on variables KASAN_SANITIZE_obj.o, KASAN_SANITIZE)
+diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
+index d16d0ace2775..836c2289b8d8 100644
+--- a/scripts/mod/modpost.c
++++ b/scripts/mod/modpost.c
+@@ -743,6 +743,8 @@ static const char *const section_white_list[] =
+ 	".gnu.lto*",
+ 	".discard.*",
+ 	".llvm.call-graph-profile",	/* call graph */
++	"__llvm_covfun",
++	"__llvm_covmap",
+ 	NULL
+ };
+ 
+-- 
+2.45.2
+

--- a/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
+++ b/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
@@ -1,0 +1,141 @@
+From eb4754739b54dac286e54e2e1f2032f1a3c0d242 Mon Sep 17 00:00:00 2001
+From: Wentao Zhang <wentaoz5@illinois.edu>
+Date: Tue, 13 Aug 2024 02:15:48 +0100
+Subject: [RFC PATCH 2/3] kbuild, llvm-cov: disable instrumentation in odd or
+ sensitive code
+
+Skip the same set of files that were not instrumented by gcov either.
+
+Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
+Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
+---
+ arch/x86/boot/Makefile                | 1 +
+ arch/x86/boot/compressed/Makefile     | 1 +
+ arch/x86/entry/vdso/Makefile          | 1 +
+ arch/x86/platform/efi/Makefile        | 1 +
+ arch/x86/purgatory/Makefile           | 1 +
+ arch/x86/realmode/rm/Makefile         | 1 +
+ arch/x86/um/vdso/Makefile             | 1 +
+ drivers/firmware/efi/libstub/Makefile | 2 ++
+ kernel/trace/Makefile                 | 1 +
+ scripts/Makefile.modfinal             | 1 +
+ 10 files changed, 11 insertions(+)
+
+diff --git a/arch/x86/boot/Makefile b/arch/x86/boot/Makefile
+index 9cc0ff6e9067..2cc2c55af305 100644
+--- a/arch/x86/boot/Makefile
++++ b/arch/x86/boot/Makefile
+@@ -57,6 +57,7 @@ KBUILD_AFLAGS	:= $(KBUILD_CFLAGS) -D__ASSEMBLY__
+ KBUILD_CFLAGS	+= $(call cc-option,-fmacro-prefix-map=$(srctree)/=)
+ KBUILD_CFLAGS	+= -fno-asynchronous-unwind-tables
+ KBUILD_CFLAGS	+= $(CONFIG_CC_IMPLICIT_FALLTHROUGH)
++LLVM_COV_PROFILE := n
+ 
+ $(obj)/bzImage: asflags-y  := $(SVGA_MODE)
+ 
+diff --git a/arch/x86/boot/compressed/Makefile b/arch/x86/boot/compressed/Makefile
+index f2051644de94..86c79c36db2e 100644
+--- a/arch/x86/boot/compressed/Makefile
++++ b/arch/x86/boot/compressed/Makefile
+@@ -43,6 +43,7 @@ KBUILD_CFLAGS += -D__DISABLE_EXPORTS
+ # Disable relocation relaxation in case the link is not PIE.
+ KBUILD_CFLAGS += $(call cc-option,-Wa$(comma)-mrelax-relocations=no)
+ KBUILD_CFLAGS += -include $(srctree)/include/linux/hidden.h
++LLVM_COV_PROFILE := n
+ 
+ # sev.c indirectly includes inat-table.h which is generated during
+ # compilation and stored in $(objtree). Add the directory to the includes so
+diff --git a/arch/x86/entry/vdso/Makefile b/arch/x86/entry/vdso/Makefile
+index c9216ac4fb1e..d9587b3b6bf2 100644
+--- a/arch/x86/entry/vdso/Makefile
++++ b/arch/x86/entry/vdso/Makefile
+@@ -156,6 +156,7 @@ quiet_cmd_vdso = VDSO    $@
+ 
+ VDSO_LDFLAGS = -shared --hash-style=both --build-id=sha1 \
+ 	$(call ld-option, --eh-frame-hdr) -Bsymbolic -z noexecstack
++LLVM_COV_PROFILE := n
+ 
+ quiet_cmd_vdso_and_check = VDSO    $@
+       cmd_vdso_and_check = $(cmd_vdso); $(cmd_vdso_check)
+diff --git a/arch/x86/platform/efi/Makefile b/arch/x86/platform/efi/Makefile
+index 500cab4a7f7c..a07852e8f3ae 100644
+--- a/arch/x86/platform/efi/Makefile
++++ b/arch/x86/platform/efi/Makefile
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ KASAN_SANITIZE := n
+ GCOV_PROFILE := n
++LLVM_COV_PROFILE := n
+ 
+ obj-$(CONFIG_EFI) 		+= memmap.o quirks.o efi.o efi_$(BITS).o \
+ 				   efi_stub_$(BITS).o
+diff --git a/arch/x86/purgatory/Makefile b/arch/x86/purgatory/Makefile
+index ebdfd7b84feb..b4e619114898 100644
+--- a/arch/x86/purgatory/Makefile
++++ b/arch/x86/purgatory/Makefile
+@@ -28,6 +28,7 @@ PURGATORY_LDFLAGS := -e purgatory_start -z nodefaultlib
+ LDFLAGS_purgatory.ro := -r $(PURGATORY_LDFLAGS)
+ LDFLAGS_purgatory.chk := $(PURGATORY_LDFLAGS)
+ targets += purgatory.ro purgatory.chk
++LLVM_COV_PROFILE := n
+ 
+ # These are adjustments to the compiler flags used for objects that
+ # make up the standalone purgatory.ro
+diff --git a/arch/x86/realmode/rm/Makefile b/arch/x86/realmode/rm/Makefile
+index a0fb39abc5c8..d36338bfa2ce 100644
+--- a/arch/x86/realmode/rm/Makefile
++++ b/arch/x86/realmode/rm/Makefile
+@@ -67,3 +67,4 @@ KBUILD_CFLAGS	:= $(REALMODE_CFLAGS) -D_SETUP -D_WAKEUP \
+ 		   -I$(srctree)/arch/x86/boot
+ KBUILD_AFLAGS	:= $(KBUILD_CFLAGS) -D__ASSEMBLY__
+ KBUILD_CFLAGS	+= -fno-asynchronous-unwind-tables
++LLVM_COV_PROFILE := n
+diff --git a/arch/x86/um/vdso/Makefile b/arch/x86/um/vdso/Makefile
+index 6a77ea6434ff..3ea2f5d123fe 100644
+--- a/arch/x86/um/vdso/Makefile
++++ b/arch/x86/um/vdso/Makefile
+@@ -60,3 +60,4 @@ quiet_cmd_vdso = VDSO    $@
+ 		 sh $(src)/checkundef.sh '$(NM)' '$@'
+ 
+ VDSO_LDFLAGS = -fPIC -shared -Wl,--hash-style=sysv -z noexecstack
++LLVM_COV_PROFILE := n
+diff --git a/drivers/firmware/efi/libstub/Makefile b/drivers/firmware/efi/libstub/Makefile
+index ed4e8ddbe76a..b8224ff291d9 100644
+--- a/drivers/firmware/efi/libstub/Makefile
++++ b/drivers/firmware/efi/libstub/Makefile
+@@ -62,6 +62,8 @@ KBUILD_CFLAGS := $(filter-out $(CC_FLAGS_LTO), $(KBUILD_CFLAGS))
+ # `-fdata-sections` flag from KBUILD_CFLAGS_KERNEL
+ KBUILD_CFLAGS_KERNEL := $(filter-out -fdata-sections, $(KBUILD_CFLAGS_KERNEL))
+ 
++LLVM_COV_PROFILE := n
++
+ lib-y				:= efi-stub-helper.o gop.o secureboot.o tpm.o \
+ 				   file.o mem.o random.o randomalloc.o pci.o \
+ 				   skip_spaces.o lib-cmdline.o lib-ctype.o \
+diff --git a/kernel/trace/Makefile b/kernel/trace/Makefile
+index 057cd975d014..0293acc50afa 100644
+--- a/kernel/trace/Makefile
++++ b/kernel/trace/Makefile
+@@ -30,6 +30,7 @@ endif
+ ifdef CONFIG_GCOV_PROFILE_FTRACE
+ GCOV_PROFILE := y
+ endif
++LLVM_COV_PROFILE := n
+ 
+ # Functions in this file could be invoked from early interrupt
+ # code and produce random code coverage.
+diff --git a/scripts/Makefile.modfinal b/scripts/Makefile.modfinal
+index 1fa98b5e952b..4fc791fff26c 100644
+--- a/scripts/Makefile.modfinal
++++ b/scripts/Makefile.modfinal
+@@ -22,6 +22,7 @@ __modfinal: $(modules:%.o=%.ko)
+ modname = $(notdir $(@:.mod.o=))
+ part-of-module = y
+ GCOV_PROFILE := n
++LLVM_COV_PROFILE := n
+ KCSAN_SANITIZE := n
+ 
+ quiet_cmd_cc_o_c = CC [M]  $@
+-- 
+2.45.2
+

--- a/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
+++ b/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
@@ -1,0 +1,103 @@
+From 93b17eac62eafb9c3cc318ef827ac4c93471985d Mon Sep 17 00:00:00 2001
+From: Chuck Wolber <chuckwolber@gmail.com>
+Date: Tue, 13 Aug 2024 02:22:46 +0100
+Subject: [RFC PATCH 3/3] llvm-cov: add Clang's MC/DC support
+
+Add Clang flags and kconfig options for measuring the kernel's modified
+condition/decision coverage (MC/DC).
+
+With Clang >= 19, users can determine the max number of conditions in a
+decision to measure via option LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS,
+which controls -fmcdc-max-conditions flag of Clang cc1 [1]. Since MC/DC
+implementation utilizes bitmaps to track the execution of test vectors,
+more memory is consumed if larger decisions are getting counted. The
+maximum value supported by Clang is 32767. According to local
+experiments, the working maximum for Linux kernel is 44, with the
+largest decisions in kernel codebase (with 45 conditions) excluded,
+otherwise the kernel image size limit will be exceeded. The largest
+decisions in kernel are contributed for example by macros checking
+CPUID.
+
+[1] https://discourse.llvm.org/t/rfc-coverage-new-algorithm-and-file-format-for-mc-dc/76798
+
+Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
+Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
+---
+ Makefile                |  6 ++++++
+ kernel/llvm-cov/Kconfig | 21 +++++++++++++++++++++
+ scripts/Makefile.lib    | 11 +++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 2ca34d00ea39..0e7ae0ffbd47 100644
+--- a/Makefile
++++ b/Makefile
+@@ -740,6 +740,12 @@ all: vmlinux
+ CFLAGS_LLVM_COV := -fprofile-instr-generate -fcoverage-mapping
+ export CFLAGS_LLVM_COV
+ 
++CFLAGS_LLVM_COV_MCDC := -fcoverage-mcdc
++ifdef CONFIG_LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS
++CFLAGS_LLVM_COV_MCDC += -Xclang -fmcdc-max-conditions=$(CONFIG_LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS)
++endif
++export CFLAGS_LLVM_COV_MCDC
++
+ CFLAGS_GCOV	:= -fprofile-arcs -ftest-coverage
+ ifdef CONFIG_CC_IS_GCC
+ CFLAGS_GCOV	+= -fno-tree-loop-im
+diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
+index b28090ba926b..d388a4adc6bc 100644
+--- a/kernel/llvm-cov/Kconfig
++++ b/kernel/llvm-cov/Kconfig
+@@ -26,5 +26,26 @@ config LLVM_COV_KERNEL
+ 	  Note that the debugfs filesystem has to be mounted to access the raw
+ 	  profile.
+ 
++config LLVM_COV_KERNEL_MCDC
++	bool "Enable measuring modified condition/decision coverage (MC/DC)"
++	depends on LLVM_COV_KERNEL
++	depends on CLANG_VERSION >= 180000
++	help
++	  This option enables measuring kernel's modified condition/decision
++	  coverage (MC/DC) with Clang's Source-based Code Coverage.
++
++	  If unsure, say N.
++
++config LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS
++	int "Maximum number of conditions in a decision to instrument"
++	range 6 32767
++	depends on LLVM_COV_KERNEL_MCDC
++	depends on CLANG_VERSION >= 190000
++	default "6"
++	help
++	  This value is passed to "-fmcdc-max-conditions" flag of Clang cc1.
++	  Expressions whose number of conditions is greater than this value will
++	  produce warnings and will not be instrumented.
++
+ endmenu
+ 
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index b9ceaee34b28..b8dfad01cb52 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -168,6 +168,17 @@ _c_flags += $(if $(patsubst n%,, \
+ 		$(CFLAGS_LLVM_COV))
+ endif
+ 
++#
++# Flag that turns on modified condition/decision coverage (MC/DC) measurement
++# with Clang's Source-based Code Coverage. Enable the flag for a file or
++# directory depending on variables LLVM_COV_PROFILE_obj.o and LLVM_COV_PROFILE.
++#
++ifeq ($(CONFIG_LLVM_COV_KERNEL_MCDC),y)
++_c_flags += $(if $(patsubst n%,, \
++		$(LLVM_COV_PROFILE_$(basetarget).o)$(LLVM_COV_PROFILE)y), \
++		$(CFLAGS_LLVM_COV_MCDC))
++endif
++
+ #
+ # Enable address sanitizer flags for kernel except some files or directories
+ # we don't want to check (depends on variables KASAN_SANITIZE_obj.o, KASAN_SANITIZE)
+-- 
+2.45.2
+

--- a/patches/v1.0/README.md
+++ b/patches/v1.0/README.md
@@ -1,0 +1,1 @@
+These patches were tested on Linux Kernel 6.11-rc3.


### PR DESCRIPTION
Port the v0.6 patches to the current upstream Linux kernel 6.11-rc3. KUnit tests caused a kernel panic, so I am reasonably certain `LLVM_COV` needs to be disabled in additional places, but this should be a start.