### PR TITLE
V0.6 patch fix and update

### DIFF
--- a/patches/v0.6/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v0.6/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -205,10 +205,10 @@ index 000000000..f6a236562
 +obj-y	+= fs.o
 diff --git a/kernel/llvm-cov/fs.c b/kernel/llvm-cov/fs.c
 new file mode 100644
-index 000000000..93586a294
+index 000000000000..917ca50d0496
 --- /dev/null
 +++ b/kernel/llvm-cov/fs.c
-@@ -0,0 +1,275 @@
+@@ -0,0 +1,253 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2019	Sami Tolvanen <samitolvanen@google.com>, Google, Inc.
@@ -411,41 +411,23 @@ index 000000000..93586a294
 +	.release	= llvm_cov_release
 +};
 +
-+/* write() implementation for llvm-cov counter reset file */
-+static ssize_t cnts_reset_write(struct file *file, const char __user *addr,
++/* write() implementation for llvm-cov reset file */
++static ssize_t reset_write(struct file *file, const char __user *addr,
 +			   size_t len, loff_t *pos)
 +{
 +	unsigned long flags;
 +
 +	flags = llvm_cov_claim_lock();
 +	memset(__llvm_prf_cnts_start, 0, __llvm_prf_cnts_size());
-+	llvm_cov_release_lock(flags);
-+
-+	return len;
-+}
-+
-+/* write() implementation for llvm-cov bitmap reset file */
-+static ssize_t bits_reset_write(struct file *file, const char __user *addr,
-+			   size_t len, loff_t *pos)
-+{
-+	unsigned long flags;
-+
-+	flags = llvm_cov_claim_lock();
 +	memset(__llvm_prf_bits_start, 0, __llvm_prf_bits_size());
 +	llvm_cov_release_lock(flags);
 +
 +	return len;
 +}
 +
-+static const struct file_operations llvm_cov_cnts_reset_fops = {
++static const struct file_operations llvm_cov_reset_fops = {
 +	.owner		= THIS_MODULE,
-+	.write		= cnts_reset_write,
-+	.llseek		= noop_llseek,
-+};
-+
-+static const struct file_operations llvm_cov_bits_reset_fops = {
-+	.owner		= THIS_MODULE,
-+	.write		= bits_reset_write,
++	.write		= reset_write,
 +	.llseek		= noop_llseek,
 +};
 +
@@ -460,12 +442,8 @@ index 000000000..93586a294
 +				 &llvm_cov_data_fops))
 +		goto err_remove;
 +
-+	if (!debugfs_create_file("cnts_reset", 0200, directory, NULL,
-+				 &llvm_cov_cnts_reset_fops))
-+		goto err_remove;
-+
-+	if (!debugfs_create_file("bits_reset", 0200, directory, NULL,
-+				 &llvm_cov_bits_reset_fops))
++	if (!debugfs_create_file("reset", 0200, directory, NULL,
++				 &llvm_cov_reset_fops))
 +		goto err_remove;
 +
 +	return 0;
@@ -484,6 +462,7 @@ index 000000000..93586a294
 +
 +module_init(llvm_cov_init);
 +module_exit(llvm_cov_exit);
+\ No newline at end of file
 diff --git a/kernel/llvm-cov/llvm-cov.h b/kernel/llvm-cov/llvm-cov.h
 new file mode 100644
 index 000000000..d9551a685

--- a/patches/v0.6/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v0.6/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -66,15 +66,6 @@ diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
 index cfb1edd25..4238c1a19 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
-@@ -45,7 +45,7 @@ config FORCE_DYNAMIC_FTRACE
- 	 in order to test the non static function tracing in the
- 	 generic code, as other architectures still use it. But we
- 	 only need to keep it around for x86_64. No need to keep it
--	 for x86_32. For x86_32, force DYNAMIC_FTRACE. 
-+	 for x86_32. For x86_32, force DYNAMIC_FTRACE.
- #
- # Arch settings
- #
 @@ -79,6 +79,7 @@ config X86
  	select ARCH_HAS_FORTIFY_SOURCE
  	select ARCH_HAS_GCOV_PROFILE_ALL


### PR DESCRIPTION
Remove an unneeded white space fragment and combine the reset files into one.

Based on Wentao Zhang's research and some of my own, I am convinced that `__llvm_profile_data` is not specifically needed at runtime. This means a combined reset function for `__llvm_prf_cnts` and `__llvm_prf_bits` is in keeping with the expected meaning of "reset". This combines the two existing reset files into a single reset file.