### PR TITLE
Continuously test patch v1.0

### DIFF
--- a/.github/workflows/llvm-trunk-linux-mainline.yml
+++ b/.github/workflows/llvm-trunk-linux-mainline.yml
@@ -1,4 +1,4 @@
-name: Test workflow with LLVM trunk and Linux v5.15.153
+name: Test workflow with LLVM trunk and Linux mainline
 
 on:
   push:
@@ -70,7 +70,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
-      run: ./ci/linux-v5.15.153/1_install_deps.sh
+      run: ./ci/linux-mainline/1_install_deps.sh
 
   pull_source:
     name: 2. Pull the source code and apply patches
@@ -86,7 +86,7 @@ jobs:
         rm -rf $MCDC_HOME
         mkdir -p $MCDC_HOME
     - name: Pull the source code and apply patches
-      run: ./ci/linux-v5.15.153/2_pull_source.sh ${{ github.repository }} ${{ github.ref_name }}
+      run: ./ci/linux-mainline/2_pull_source.sh ${{ github.repository }} ${{ github.ref_name }}
 
   get_llvm:
     name: 3. Get LLVM
@@ -98,7 +98,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build from source
-      run: ./ci/linux-v5.15.153/3_get_llvm.sh
+      run: ./ci/linux-mainline/3_get_llvm.sh
     - name: Print LLVM build resource usage
       run: |
         cat /tmp/time.log
@@ -120,7 +120,7 @@ jobs:
         clang -v
         llc --version
     - name: Build the kernel
-      run: ./ci/linux-v5.15.153/4_build_kernel.sh
+      run: ./ci/linux-mainline/4_build_kernel.sh
     - name: Print full kernel build log
       run: cat /tmp/make.log
     - name: Print kernel build resource usage
@@ -147,7 +147,7 @@ jobs:
         clang -v
         llc --version
     - name: Boot the kernel and collect coverage
-      run: ./ci/linux-v5.15.153/5_boot_kernel_and_collect_coverage.sh
+      run: ./ci/linux-mainline/5_boot_kernel_and_collect_coverage.sh
     - name: Print the index of coverage report (immediately after reset)
       run: cat $MCDC_HOME/analysis_reset/text-coverage-reports/index.txt
     - name: Print the index of coverage report

--- a/.github/workflows/llvm-trunk-linux-v5.15.153.yml
+++ b/.github/workflows/llvm-trunk-linux-v5.15.153.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - llvm-trunk
+    - llvm-trunk-next
     paths:
     - '.github/workflows/**'
     - 'ci/**'
@@ -39,7 +40,7 @@ on:
 # ought to be jobs? and what ought to be steps?
 
 concurrency:
-  group: xlab-uiuc/linux-mcdc
+  group: ${{ github.repository }}
 
 env:
   MCDC_HOME: /home/github-runner/mcdc-workdir
@@ -82,7 +83,7 @@ jobs:
         rm -rf $MCDC_HOME
         mkdir -p $MCDC_HOME
     - name: Pull the source code and apply patches
-      run: ./ci/linux-v5.15.153/2_pull_source.sh
+      run: ./ci/linux-v5.15.153/2_pull_source.sh ${{ github.repository }} ${{ github.ref_name }}
 
   get_llvm:
     name: 3. Get LLVM

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Measure Linux kernel's modified condition/decision coverage (MC/DC)
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/xlab-uiuc/linux-mcdc/llvm-trunk-linux-v5.15.153.yml?label=LLVM%20trunk%2BLinux%20v5.15.153)](https://github.com/xlab-uiuc/linux-mcdc/actions/workflows/llvm-trunk.yml)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/xlab-uiuc/linux-mcdc/llvm-18.yml?label=LLVM%2018%2BLinux%20v5.15.153)](https://github.com/xlab-uiuc/linux-mcdc/actions/workflows/llvm-18.yml)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/xlab-uiuc/linux-mcdc/llvm-trunk-linux-mainline.yml?label=LLVM%20trunk%2BLinux%20mainline)](https://github.com/xlab-uiuc/linux-mcdc/actions/workflows/llvm-trunk-linux-mainline.yml)
+
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/xlab-uiuc/linux-mcdc/llvm-trunk-linux-v5.15.153.yml?label=LLVM%20trunk%2BLinux%20v5.15.153)](https://github.com/xlab-uiuc/linux-mcdc/actions/workflows/llvm-trunk-linux-v5.15.153.yml)
 
 This repository demonstrates [KUnit](https://docs.kernel.org/dev-tools/kunit/index.html)'s
 modified condition/decision coverage (MC/DC) of 5.15.y Linux kernel using

--- a/ci/linux-mainline/1_install_deps.sh
+++ b/ci/linux-mainline/1_install_deps.sh
@@ -1,0 +1,1 @@
+../linux-v5.15.153/1_install_deps.sh

--- a/ci/linux-mainline/2_pull_source.sh
+++ b/ci/linux-mainline/2_pull_source.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+repo=${1:-"xlab-uiuc/linux-mcdc"}
+branch=${2:-"llvm-trunk-next"}
+
+echo $repo
+echo $branch
+
+kernel_latest_tag=v$(
+    curl -s https://www.kernel.org/releases.json | jq -r '.releases[0].version'
+)
+echo $kernel_latest_tag
+if [[ "$kernel_latest_tag" != "v6.11-rc3" ]]; then
+    echo "There are updates in upstream. Patch v1.0 needs to be rebased."
+    # Fail on purpose as likely we have to resolve some conflicts
+    exit 1
+fi
+
+cd $MCDC_HOME
+
+# This meta repository
+git clone https://github.com/$repo.git --branch $branch
+# LLVM if we want to build it from source (optional)
+git clone https://github.com/llvm/llvm-project.git --depth 5
+# Linux kernel
+git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --branch $kernel_latest_tag --depth 5
+
+# Apply kernel patches
+cd $MCDC_HOME/linux
+git apply $MCDC_HOME/linux-mcdc/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+git apply $MCDC_HOME/linux-mcdc/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
+git apply $MCDC_HOME/linux-mcdc/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch

--- a/ci/linux-mainline/2_pull_source.sh
+++ b/ci/linux-mainline/2_pull_source.sh
@@ -28,7 +28,7 @@ fi
 # LLVM if we want to build it from source (optional)
 git clone https://github.com/llvm/llvm-project.git --depth 5
 # Linux kernel
-git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --branch $kernel_latest_tag --depth 5
+git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch $kernel_latest_tag --depth 5
 
 # Apply kernel patches
 cd $MCDC_HOME/linux

--- a/ci/linux-mainline/2_pull_source.sh
+++ b/ci/linux-mainline/2_pull_source.sh
@@ -6,20 +6,25 @@ branch=${2:-"llvm-trunk-next"}
 echo $repo
 echo $branch
 
+cd $MCDC_HOME
+
+# This meta repository
+git clone https://github.com/$repo.git --branch $branch
+
 kernel_latest_tag=v$(
     curl -s https://www.kernel.org/releases.json | jq -r '.releases[0].version'
 )
 echo $kernel_latest_tag
-if [[ "$kernel_latest_tag" != "v6.11-rc3" ]]; then
+current_base=v$(
+    cat $MCDC_HOME/linux-mcdc/patches/v1.0/README.md | rev | cut -d ' ' -f 1 | cut -d . -f 2- | rev
+)
+echo $current_base
+if [[ "$kernel_latest_tag" != "$current_base" ]]; then
     echo "There are updates in upstream. Patch v1.0 needs to be rebased."
     # Fail on purpose as likely we have to resolve some conflicts
     exit 1
 fi
 
-cd $MCDC_HOME
-
-# This meta repository
-git clone https://github.com/$repo.git --branch $branch
 # LLVM if we want to build it from source (optional)
 git clone https://github.com/llvm/llvm-project.git --depth 5
 # Linux kernel

--- a/ci/linux-mainline/3_get_llvm.sh
+++ b/ci/linux-mainline/3_get_llvm.sh
@@ -1,0 +1,1 @@
+../linux-v5.15.153/3_get_llvm.sh

--- a/ci/linux-mainline/4_build_kernel.sh
+++ b/ci/linux-mainline/4_build_kernel.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+cd $MCDC_HOME/linux
+make LLVM=1 defconfig
+
+./scripts/config -e CONFIG_9P_FS_POSIX_ACL
+./scripts/config -e CONFIG_9P_FS
+./scripts/config -e CONFIG_NET_9P_VIRTIO
+./scripts/config -e CONFIG_NET_9P
+./scripts/config -e CONFIG_PCI
+./scripts/config -e CONFIG_VIRTIO_PCI
+./scripts/config -e CONFIG_OVERLAY_FS
+./scripts/config -e CONFIG_DEBUG_FS
+./scripts/config -e CONFIG_CONFIGFS_FS
+./scripts/config -e CONFIG_MAGIC_SYSRQ
+make LLVM=1 olddefconfig
+
+./scripts/config -e CONFIG_KUNIT
+./scripts/config -e CONFIG_KUNIT_ALL_TESTS
+# See https://github.com/xlab-uiuc/linux-mcdc/pull/10#issuecomment-2291603705
+./scripts/config -d CONFIG_KUNIT_FAULT_TEST
+make LLVM=1 olddefconfig
+
+./scripts/config -e CONFIG_LLVM_COV_KERNEL
+./scripts/config -e CONFIG_LLVM_COV_KERNEL_MCDC
+./scripts/config --set-val LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS 44
+make LLVM=1 olddefconfig
+
+cat << EOF
+Building the kernel with output suppressed. The log tail will be displayed once
+the process finishes. See the full log in the next step.
+EOF
+/usr/bin/time -v -o /tmp/time.log make LLVM=1 -j$(nproc) >& /tmp/make.log
+tail -n 200 /tmp/make.log

--- a/ci/linux-mainline/5_boot_kernel_and_collect_coverage.sh
+++ b/ci/linux-mainline/5_boot_kernel_and_collect_coverage.sh
@@ -1,0 +1,1 @@
+../linux-v5.15.153/5_boot_kernel_and_collect_coverage.sh

--- a/ci/linux-v5.15.153/1_install_deps.sh
+++ b/ci/linux-v5.15.153/1_install_deps.sh
@@ -9,3 +9,6 @@ sudo apt-get -yq install git bc libncurses-dev wget busybox \
 
 # For booting the kernel
 sudo apt-get -yq install qemu-system-x86
+
+# Only needed in CI
+sudo apt-get -yq install jq

--- a/ci/linux-v5.15.153/2_pull_source.sh
+++ b/ci/linux-v5.15.153/2_pull_source.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+repo=${1:-"xlab-uiuc/linux-mcdc"}
+branch=${2:-"llvm-trunk-next"}
+
+echo $repo
+echo $branch
+
 cd $MCDC_HOME
 
 # This meta repository
-git clone https://github.com/xlab-uiuc/linux-mcdc.git --branch llvm-trunk
+git clone https://github.com/$repo.git --branch $branch
 # LLVM if we want to build it from source (optional)
 git clone https://github.com/llvm/llvm-project.git --depth 5
 # Linux kernel

--- a/patches/v1.0/0000-cover-letter.patch
+++ b/patches/v1.0/0000-cover-letter.patch
@@ -1,6 +1,6 @@
-From 0f3be98299c1331dd6a8d1fb0ad7bf94f18f2ebe Mon Sep 17 00:00:00 2001
+From 87bf30b201d2e8a85e11e79c7f3254f8ca974f30 Mon Sep 17 00:00:00 2001
 From: Wentao Zhang <wentaoz5@illinois.edu>
-Date: Thu, 18 Jul 2024 13:14:06 -0500
+Date: Sun, 18 Aug 2024 18:50:22 -0500
 Subject: [RFC PATCH 0/3] Enable measuring the kernel's Source-based Code Coverage and MC/DC with Clang
 
 This patch series adds support for building x86-64 kernels with Clang's Source-
@@ -107,7 +107,7 @@ community's feedback.
 
 [1] https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
 [2] https://digital-library.theiet.org/content/journals/10.1049/sej.1994.0025
-[3] https://lore.kernel.org/linux-doc/20210407211704.367039-1-morbo@google.com/
+[3] https://lore.kernel.org/lkml/20210407211704.367039-1-morbo@google.com/
 [4] https://github.com/xlab-uiuc/linux-mcdc
 [5] https://lpc.events/event/18/contributions/1718/
 

--- a/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -1,6 +1,6 @@
-From 87f04331a2b7be8d16ce09b41a4911a5a0ee710f Mon Sep 17 00:00:00 2001
+From 6411f59ee41b2b1fc35df594564105e88fbf31e6 Mon Sep 17 00:00:00 2001
 From: Wentao Zhang <wentaoz5@illinois.edu>
-Date: Tue, 13 Aug 2024 01:45:17 +0100
+Date: Wed, 14 Aug 2024 15:42:58 -0500
 Subject: [RFC PATCH 1/3] llvm-cov: add Clang's Source-based Code Coverage
  support
 
@@ -16,7 +16,7 @@ required for high assurance), we do instrumentation at the compiler
 frontend, instead of IR; we care about counters and bitmaps, but not
 value profiling.
 
-[1] https://lore.kernel.org/linux-doc/20210407211704.367039-1-morbo@google.com/
+[1] https://lore.kernel.org/lkml/20210407211704.367039-1-morbo@google.com/
 
 Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
 Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
@@ -40,7 +40,7 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  create mode 100644 kernel/llvm-cov/llvm-cov.h
 
 diff --git a/Makefile b/Makefile
-index 0a364e34f50b..2ca34d00ea39 100644
+index 68ebd6d6b..1750a2b7d 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -737,6 +737,9 @@ endif # KBUILD_EXTMOD
@@ -54,7 +54,7 @@ index 0a364e34f50b..2ca34d00ea39 100644
  ifdef CONFIG_CC_IS_GCC
  CFLAGS_GCOV	+= -fno-tree-loop-im
 diff --git a/arch/Kconfig b/arch/Kconfig
-index 975dd22a2dbd..0727265f677f 100644
+index 975dd22a2..0727265f6 100644
 --- a/arch/Kconfig
 +++ b/arch/Kconfig
 @@ -1601,6 +1601,7 @@ config ARCH_HAS_KERNEL_FPU_SUPPORT
@@ -66,7 +66,7 @@ index 975dd22a2dbd..0727265f677f 100644
  source "scripts/gcc-plugins/Kconfig"
  
 diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index 007bab9f2a0e..87a793b82bab 100644
+index 007bab9f2..87a793b82 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
 @@ -85,6 +85,7 @@ config X86
@@ -78,7 +78,7 @@ index 007bab9f2a0e..87a793b82bab 100644
  	select ARCH_HAS_MEM_ENCRYPT
  	select ARCH_HAS_MEMBARRIER_SYNC_CORE
 diff --git a/arch/x86/kernel/vmlinux.lds.S b/arch/x86/kernel/vmlinux.lds.S
-index 6e73403e874f..90433772240a 100644
+index 6e73403e8..904337722 100644
 --- a/arch/x86/kernel/vmlinux.lds.S
 +++ b/arch/x86/kernel/vmlinux.lds.S
 @@ -191,6 +191,8 @@ SECTIONS
@@ -91,7 +91,7 @@ index 6e73403e874f..90433772240a 100644
  
  	. = ALIGN(PAGE_SIZE);
 diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
-index 1ae44793132a..770ff8469dcd 100644
+index 1ae447931..770ff8469 100644
 --- a/include/asm-generic/vmlinux.lds.h
 +++ b/include/asm-generic/vmlinux.lds.h
 @@ -334,6 +334,44 @@
@@ -140,7 +140,7 @@ index 1ae44793132a..770ff8469dcd 100644
  	STRUCT_ALIGN();							\
  	__dtb_start = .;						\
 diff --git a/kernel/Makefile b/kernel/Makefile
-index 3c13240dfc9f..773e6a9ee00a 100644
+index 3c13240df..773e6a9ee 100644
 --- a/kernel/Makefile
 +++ b/kernel/Makefile
 @@ -117,6 +117,7 @@ obj-$(CONFIG_HAVE_STATIC_CALL) += static_call.o
@@ -153,7 +153,7 @@ index 3c13240dfc9f..773e6a9ee00a 100644
  
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
 new file mode 100644
-index 000000000000..b28090ba926b
+index 000000000..b28090ba9
 --- /dev/null
 +++ b/kernel/llvm-cov/Kconfig
 @@ -0,0 +1,30 @@
@@ -189,7 +189,7 @@ index 000000000000..b28090ba926b
 +
 diff --git a/kernel/llvm-cov/Makefile b/kernel/llvm-cov/Makefile
 new file mode 100644
-index 000000000000..a0f45e05f8fb
+index 000000000..a0f45e05f
 --- /dev/null
 +++ b/kernel/llvm-cov/Makefile
 @@ -0,0 +1,5 @@
@@ -201,7 +201,7 @@ index 000000000000..a0f45e05f8fb
 \ No newline at end of file
 diff --git a/kernel/llvm-cov/fs.c b/kernel/llvm-cov/fs.c
 new file mode 100644
-index 000000000000..917ca50d0496
+index 000000000..917ca50d0
 --- /dev/null
 +++ b/kernel/llvm-cov/fs.c
 @@ -0,0 +1,253 @@
@@ -461,7 +461,7 @@ index 000000000000..917ca50d0496
 \ No newline at end of file
 diff --git a/kernel/llvm-cov/llvm-cov.h b/kernel/llvm-cov/llvm-cov.h
 new file mode 100644
-index 000000000000..4a91b3c8ed72
+index 000000000..4a91b3c8e
 --- /dev/null
 +++ b/kernel/llvm-cov/llvm-cov.h
 @@ -0,0 +1,156 @@
@@ -623,7 +623,7 @@ index 000000000000..4a91b3c8ed72
 +#endif /* _LLVM_COV_H */
 \ No newline at end of file
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index fe3668dc4954..b9ceaee34b28 100644
+index fe3668dc4..b9ceaee34 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -158,6 +158,16 @@ _c_flags += $(if $(patsubst n%,, \
@@ -644,7 +644,7 @@ index fe3668dc4954..b9ceaee34b28 100644
  # Enable address sanitizer flags for kernel except some files or directories
  # we don't want to check (depends on variables KASAN_SANITIZE_obj.o, KASAN_SANITIZE)
 diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
-index d16d0ace2775..836c2289b8d8 100644
+index d16d0ace2..836c2289b 100644
 --- a/scripts/mod/modpost.c
 +++ b/scripts/mod/modpost.c
 @@ -743,6 +743,8 @@ static const char *const section_white_list[] =
@@ -657,5 +657,5 @@ index d16d0ace2775..836c2289b8d8 100644
  };
  
 -- 
-2.45.2
+2.34.1
 

--- a/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
+++ b/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
@@ -1,6 +1,6 @@
-From eb4754739b54dac286e54e2e1f2032f1a3c0d242 Mon Sep 17 00:00:00 2001
+From 40f0997c24f32b2215318cf6e62b14b31854294c Mon Sep 17 00:00:00 2001
 From: Wentao Zhang <wentaoz5@illinois.edu>
-Date: Tue, 13 Aug 2024 02:15:48 +0100
+Date: Wed, 14 Aug 2024 15:43:44 -0500
 Subject: [RFC PATCH 2/3] kbuild, llvm-cov: disable instrumentation in odd or
  sensitive code
 
@@ -22,7 +22,7 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  10 files changed, 11 insertions(+)
 
 diff --git a/arch/x86/boot/Makefile b/arch/x86/boot/Makefile
-index 9cc0ff6e9067..2cc2c55af305 100644
+index 9cc0ff6e9..2cc2c55af 100644
 --- a/arch/x86/boot/Makefile
 +++ b/arch/x86/boot/Makefile
 @@ -57,6 +57,7 @@ KBUILD_AFLAGS	:= $(KBUILD_CFLAGS) -D__ASSEMBLY__
@@ -34,7 +34,7 @@ index 9cc0ff6e9067..2cc2c55af305 100644
  $(obj)/bzImage: asflags-y  := $(SVGA_MODE)
  
 diff --git a/arch/x86/boot/compressed/Makefile b/arch/x86/boot/compressed/Makefile
-index f2051644de94..86c79c36db2e 100644
+index f2051644d..86c79c36d 100644
 --- a/arch/x86/boot/compressed/Makefile
 +++ b/arch/x86/boot/compressed/Makefile
 @@ -43,6 +43,7 @@ KBUILD_CFLAGS += -D__DISABLE_EXPORTS
@@ -46,7 +46,7 @@ index f2051644de94..86c79c36db2e 100644
  # sev.c indirectly includes inat-table.h which is generated during
  # compilation and stored in $(objtree). Add the directory to the includes so
 diff --git a/arch/x86/entry/vdso/Makefile b/arch/x86/entry/vdso/Makefile
-index c9216ac4fb1e..d9587b3b6bf2 100644
+index c9216ac4f..d9587b3b6 100644
 --- a/arch/x86/entry/vdso/Makefile
 +++ b/arch/x86/entry/vdso/Makefile
 @@ -156,6 +156,7 @@ quiet_cmd_vdso = VDSO    $@
@@ -58,7 +58,7 @@ index c9216ac4fb1e..d9587b3b6bf2 100644
  quiet_cmd_vdso_and_check = VDSO    $@
        cmd_vdso_and_check = $(cmd_vdso); $(cmd_vdso_check)
 diff --git a/arch/x86/platform/efi/Makefile b/arch/x86/platform/efi/Makefile
-index 500cab4a7f7c..a07852e8f3ae 100644
+index 500cab4a7..a07852e8f 100644
 --- a/arch/x86/platform/efi/Makefile
 +++ b/arch/x86/platform/efi/Makefile
 @@ -1,6 +1,7 @@
@@ -70,7 +70,7 @@ index 500cab4a7f7c..a07852e8f3ae 100644
  obj-$(CONFIG_EFI) 		+= memmap.o quirks.o efi.o efi_$(BITS).o \
  				   efi_stub_$(BITS).o
 diff --git a/arch/x86/purgatory/Makefile b/arch/x86/purgatory/Makefile
-index ebdfd7b84feb..b4e619114898 100644
+index ebdfd7b84..b4e619114 100644
 --- a/arch/x86/purgatory/Makefile
 +++ b/arch/x86/purgatory/Makefile
 @@ -28,6 +28,7 @@ PURGATORY_LDFLAGS := -e purgatory_start -z nodefaultlib
@@ -82,7 +82,7 @@ index ebdfd7b84feb..b4e619114898 100644
  # These are adjustments to the compiler flags used for objects that
  # make up the standalone purgatory.ro
 diff --git a/arch/x86/realmode/rm/Makefile b/arch/x86/realmode/rm/Makefile
-index a0fb39abc5c8..d36338bfa2ce 100644
+index a0fb39abc..d36338bfa 100644
 --- a/arch/x86/realmode/rm/Makefile
 +++ b/arch/x86/realmode/rm/Makefile
 @@ -67,3 +67,4 @@ KBUILD_CFLAGS	:= $(REALMODE_CFLAGS) -D_SETUP -D_WAKEUP \
@@ -91,7 +91,7 @@ index a0fb39abc5c8..d36338bfa2ce 100644
  KBUILD_CFLAGS	+= -fno-asynchronous-unwind-tables
 +LLVM_COV_PROFILE := n
 diff --git a/arch/x86/um/vdso/Makefile b/arch/x86/um/vdso/Makefile
-index 6a77ea6434ff..3ea2f5d123fe 100644
+index 6a77ea643..3ea2f5d12 100644
 --- a/arch/x86/um/vdso/Makefile
 +++ b/arch/x86/um/vdso/Makefile
 @@ -60,3 +60,4 @@ quiet_cmd_vdso = VDSO    $@
@@ -100,7 +100,7 @@ index 6a77ea6434ff..3ea2f5d123fe 100644
  VDSO_LDFLAGS = -fPIC -shared -Wl,--hash-style=sysv -z noexecstack
 +LLVM_COV_PROFILE := n
 diff --git a/drivers/firmware/efi/libstub/Makefile b/drivers/firmware/efi/libstub/Makefile
-index ed4e8ddbe76a..b8224ff291d9 100644
+index ed4e8ddbe..b8224ff29 100644
 --- a/drivers/firmware/efi/libstub/Makefile
 +++ b/drivers/firmware/efi/libstub/Makefile
 @@ -62,6 +62,8 @@ KBUILD_CFLAGS := $(filter-out $(CC_FLAGS_LTO), $(KBUILD_CFLAGS))
@@ -113,7 +113,7 @@ index ed4e8ddbe76a..b8224ff291d9 100644
  				   file.o mem.o random.o randomalloc.o pci.o \
  				   skip_spaces.o lib-cmdline.o lib-ctype.o \
 diff --git a/kernel/trace/Makefile b/kernel/trace/Makefile
-index 057cd975d014..0293acc50afa 100644
+index 057cd975d..0293acc50 100644
 --- a/kernel/trace/Makefile
 +++ b/kernel/trace/Makefile
 @@ -30,6 +30,7 @@ endif
@@ -125,7 +125,7 @@ index 057cd975d014..0293acc50afa 100644
  # Functions in this file could be invoked from early interrupt
  # code and produce random code coverage.
 diff --git a/scripts/Makefile.modfinal b/scripts/Makefile.modfinal
-index 1fa98b5e952b..4fc791fff26c 100644
+index 1fa98b5e9..4fc791fff 100644
 --- a/scripts/Makefile.modfinal
 +++ b/scripts/Makefile.modfinal
 @@ -22,6 +22,7 @@ __modfinal: $(modules:%.o=%.ko)
@@ -137,5 +137,5 @@ index 1fa98b5e952b..4fc791fff26c 100644
  
  quiet_cmd_cc_o_c = CC [M]  $@
 -- 
-2.45.2
+2.34.1
 

--- a/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
+++ b/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
@@ -1,6 +1,6 @@
-From 93b17eac62eafb9c3cc318ef827ac4c93471985d Mon Sep 17 00:00:00 2001
-From: Chuck Wolber <chuckwolber@gmail.com>
-Date: Tue, 13 Aug 2024 02:22:46 +0100
+From 87bf30b201d2e8a85e11e79c7f3254f8ca974f30 Mon Sep 17 00:00:00 2001
+From: Wentao Zhang <wentaoz5@illinois.edu>
+Date: Wed, 14 Aug 2024 15:45:32 -0500
 Subject: [RFC PATCH 3/3] llvm-cov: add Clang's MC/DC support
 
 Add Clang flags and kconfig options for measuring the kernel's modified
@@ -29,7 +29,7 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  3 files changed, 38 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 2ca34d00ea39..0e7ae0ffbd47 100644
+index 1750a2b7d..4aa263e5f 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -740,6 +740,12 @@ all: vmlinux
@@ -46,7 +46,7 @@ index 2ca34d00ea39..0e7ae0ffbd47 100644
  ifdef CONFIG_CC_IS_GCC
  CFLAGS_GCOV	+= -fno-tree-loop-im
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
-index b28090ba926b..d388a4adc6bc 100644
+index b28090ba9..d388a4adc 100644
 --- a/kernel/llvm-cov/Kconfig
 +++ b/kernel/llvm-cov/Kconfig
 @@ -26,5 +26,26 @@ config LLVM_COV_KERNEL
@@ -77,7 +77,7 @@ index b28090ba926b..d388a4adc6bc 100644
  endmenu
  
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index b9ceaee34b28..b8dfad01cb52 100644
+index b9ceaee34..b8dfad01c 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -168,6 +168,17 @@ _c_flags += $(if $(patsubst n%,, \
@@ -99,5 +99,5 @@ index b9ceaee34b28..b8dfad01cb52 100644
  # Enable address sanitizer flags for kernel except some files or directories
  # we don't want to check (depends on variables KASAN_SANITIZE_obj.o, KASAN_SANITIZE)
 -- 
-2.45.2
+2.34.1
 

--- a/patches/v1.0/README.md
+++ b/patches/v1.0/README.md
@@ -1,1 +1,1 @@
-These patches were tested on Linux Kernel 6.11-rc3.
+These patches were tested on Linux Kernel 6.11-rc4.


### PR DESCRIPTION
Test the functionality of patch v1.0 daily, whose base should be the latest tag in upstream.

Once upstream has released new tags, the CI would fail so that we are aware of it and rebase the patch in time.
