### PR TITLE
V1.0 patch cleanup

### DIFF
--- a/patches/v1.0/0000-cover-letter.patch
+++ b/patches/v1.0/0000-cover-letter.patch
@@ -146,6 +146,6 @@ Wentao Zhang (3):
  create mode 100644 kernel/llvm-cov/fs.c
  create mode 100644 kernel/llvm-cov/llvm-cov.h
 
---
-2.34.1
+-- 
+2.45.2
 

--- a/patches/v1.0/0000-cover-letter.patch
+++ b/patches/v1.0/0000-cover-letter.patch
@@ -3,19 +3,23 @@ From: Wentao Zhang <wentaoz5@illinois.edu>
 Date: Sun, 18 Aug 2024 18:50:22 -0500
 Subject: [RFC PATCH 0/3] Enable measuring the kernel's Source-based Code Coverage and MC/DC with Clang
 
-This patch series adds support for building x86-64 kernels with Clang's Source-
-based Code Coverage and measuring modified condition/decision coverage (MC/DC).
+This series adds support for building x86-64 kernels with Clang's Source-
+based Code Coverage[1] in order to facilitate Modified Condition/Decision
+Coverage (MC/DC)[2] that provably correlates to source code for all levels of
+compiler optimization.
 
 The newly added kernel/llvm-cov/ directory complements the existing gcov
-implementation. gcov works at a lower level and may better reflect the actual
-execution of object code. However, it lacks the necessary information to connect
-coverage measurement back to source code locations and gcov reports are
-sometimes confusing. With a nonzero optimization level (which is the default
-when building the kernel), it's even harder to rebuild the mapping between
-coverage reports and source code. In the following example from
-drivers/firmware/dmi_scan.c, an expression with four leaf conditions are
-reported to have six branch outcomes, which is not ideally informative in many
-use cases.
+implementation. Gcov works at the object code level which may better reflect
+actual execution. However, Gcov lacks the necessary information to correlate
+coverage measurement with source code location when compiler optimization
+level is non-zero (which is the default when building the kernel). In addition,
+gcov reports are occasionally ambiguous when attempting to compare with
+source code level developer intent.
+
+In the following gcov example from drivers/firmware/dmi_scan.c, an expression
+with four conditions is reported to have six branch outcomes, which is not
+ideally informative in many safety related use cases, such as automotive,
+medical, and aerospace.
 
         5: 1068:	if (s == e || *e != '/' || !month || month > 12) {
 branch  0 taken 5 (fallthrough)
@@ -25,12 +29,12 @@ branch  3 taken 0
 branch  4 taken 0 (fallthrough)
 branch  5 taken 5
 
-On the other hand, Clang's Source-based Code Coverage [1] does instrumentation
-at the compiler frontend and maintains accurate mapping from coverage measure to
-source code locations. The generated reports can reflect exactly how the code is
+On the other hand, Clang's Source-based Code Coverage instruments at the
+compiler frontend which maintains an accurate mapping from coverage measurement
+to source code location. Coverage reports reflect exactly how the code is
 written regardless of optimization and can present advanced metrics like branch
-coverage and MC/DC in a more human-friendly way. Coverage report for the same
-snippet by llvm-cov would look like the below:
+coverage and MC/DC in a clearer way. Coverage report for the same snippet by
+llvm-cov would look as follows:
 
  1068|      5|	if (s == e || *e != '/' || !month || month > 12) {
   ------------------
@@ -40,11 +44,12 @@ snippet by llvm-cov would look like the below:
   |  Branch (1068:39): [True: 0, False: 5]
   ------------------
 
-Clang has also added MC/DC support since its release 18.1.0. MC/DC is a fine-
+Clang has added MC/DC support as of its 18.1.0 release. MC/DC is a fine-
 grained coverage metric required by many automotive and aviation industrial
-standards for certifying mission-critical software [2]. In the following example
-from arch/x86/events/probe.c, llvm-cov gives the MC/DC measure for the decision
-at line 43.
+standards for certifying mission-critical software [3].
+
+In the following example from arch/x86/events/probe.c, llvm-cov gives the
+MC/DC measurement for the compound logic decision at line 43.
 
    43|     12|			if (msr[bit].test && !msr[bit].test(bit, data))
   ------------------
@@ -67,13 +72,14 @@ at line 43.
   ------------------
    44|      5|				continue;
 
-As the results suggest, during the given span of measurement, only condition C2
+As the results suggest, during the span of measurement, only condition C2
 (!msr[bit].test(bit, data)) is covered. That means C2 was evaluated to both true
-and false and in those test vectors C2 affected the decision outcome
-independently. Therefore MC/DC for the shown decision is 1 out of 2 (50.00%).
+and false, and in those test vectors C2 affected the decision outcome
+independently. Therefore MC/DC for this decision is 1 out of 2 (50.00%).
 
 To do a full kernel measurement, instrument the kernel with LLVM_COV_KERNEL_MCDC
-enabled, run the testsuites, and collect the raw profile data under
+enabled, and optionally set a LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS value (the
+default is six). Run the testsuites, and collect the raw profile data under
 /sys/kernel/debug/llvm-cov/profraw. Such raw profile data can be merged and
 indexed, and used for generating coverage reports in various formats.
 
@@ -83,14 +89,14 @@ indexed, and used for generating coverage reports in various formats.
                   --format=text --use-color=false -output-dir=coverage_reports \
                   -instr-profile vmlinux.profdata vmlinux
 
-The first patch in the series enables Clang's Source-based Code Coverage for the
-kernel. The second patch disables instrumenting the same set of files that were
-skipped by kernel/gcov/ as well. The third patch enables MC/DC instrumentation
-which is built on top of Source-based Code Coverage.
+The first patch in this series enables Clang's Source-based Code Coverage in the
+kernel. The second patch disables instrumentation in the same areas that were
+disabled for kernel/gcov/. The third patch adds kernel configuration directives
+to enable MC/DC instrumentation.
 
-This work reuses a portion of code from a previous effort by Sami Tolvanen et
-al. [3], but we aim for source-based *code coverage* required for high assurance
-(MC/DC) while [3] focused more on performance optimization.
+This work reuses code from a previous effort by Sami Tolvanen et al. [4]. Our
+aim is for source-based *code coverage* required for high assurance (MC/DC)
+while [4] focused more on performance optimization.
 
 This initial submission is restricted to x86-64. Support for other architectures
 would need a bit more Makefile & linker script modification. Informally we've
@@ -101,15 +107,37 @@ Clang's gcov support in kernel/gcov/. Currently, kernel/gcov/ is not able to
 measure MC/DC without modifying CFLAGS_GCOV and it would face the same issues in
 terms of source correlation as gcov in general does.
 
-Some demo and results can be found in [4]. We will talk about this patch series
-in the Refereed Track of LPC 2024 [5] and would really like to hear the
-community's feedback.
+Some demo and results can be found in [5]. We will talk about this patch series
+in the Refereed Track at LPC 2024 [6] and would appreciate the community's
+feedback.
+
+Known Limitations:
+
+Kernel code with logical expressions exceeding
+LVM_COV_KERNEL_MCDC_MAX_CONDITIONS will produce a compiler warning.
+Expressions with up to 45 conditions are found in the Linux kernel source
+tree, but 44 seems to be the max value before the build fails due to
+kernel size. As of LLVM 19 the max number of conditions possible is 32767.
+
+As of LLVM 19, certain expressions are still not covered, and will produce
+build warnings when they are encountered:
+
+"[...] if a boolean expression is embedded in the nest of another boolean
+ expression but separated by a non-logical operator, this is also not
+ supported. For example, in x = (a && b && c && func(d && f)), the d && f
+ case starts a new boolean expression that is separated from the other
+ conditions by the operator func(). When this is encountered, a warning
+ will be generated and the boolean expression will not be
+ instrumented." [7]
+
 
 [1] https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
-[2] https://digital-library.theiet.org/content/journals/10.1049/sej.1994.0025
-[3] https://lore.kernel.org/lkml/20210407211704.367039-1-morbo@google.com/
-[4] https://github.com/xlab-uiuc/linux-mcdc
-[5] https://lpc.events/event/18/contributions/1718/
+[2] https://en.wikipedia.org/wiki/Modified_condition%2Fdecision_coverage
+[3] https://digital-library.theiet.org/content/journals/10.1049/sej.1994.0025
+[4] https://lore.kernel.org/lkml/20210407211704.367039-1-morbo@google.com/
+[5] https://github.com/xlab-uiuc/linux-mcdc
+[6] https://lpc.events/event/18/contributions/1718/
+[7] https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#mc-dc-instrumentation
 
 Wentao Zhang (3):
   [RFC PATCH 1/3] llvm-cov: add Clang's Source-based Code Coverage

--- a/patches/v1.0/0000-cover-letter.patch
+++ b/patches/v1.0/0000-cover-letter.patch
@@ -160,7 +160,7 @@ Wentao Zhang (3):
  drivers/firmware/efi/libstub/Makefile |   2 +
  include/asm-generic/vmlinux.lds.h     |  38 ++++
  kernel/Makefile                       |   1 +
- kernel/llvm-cov/Kconfig               |  51 ++++++
+ kernel/llvm-cov/Kconfig               |  50 +++++
  kernel/llvm-cov/Makefile              |   5 +
  kernel/llvm-cov/fs.c                  | 253 ++++++++++++++++++++++++++
  kernel/llvm-cov/llvm-cov.h            | 156 ++++++++++++++++
@@ -168,7 +168,7 @@ Wentao Zhang (3):
  scripts/Makefile.lib                  |  21 +++
  scripts/Makefile.modfinal             |   1 +
  scripts/mod/modpost.c                 |   2 +
- 22 files changed, 551 insertions(+)
+ 22 files changed, 550 insertions(+)
  create mode 100644 kernel/llvm-cov/Kconfig
  create mode 100644 kernel/llvm-cov/Makefile
  create mode 100644 kernel/llvm-cov/fs.c

--- a/patches/v1.0/0000-cover-letter.patch
+++ b/patches/v1.0/0000-cover-letter.patch
@@ -5,21 +5,21 @@ Subject: [RFC PATCH 0/3] Enable measuring the kernel's Source-based Code Coverag
 
 This series adds support for building x86-64 kernels with Clang's Source-
 based Code Coverage[1] in order to facilitate Modified Condition/Decision
-Coverage (MC/DC)[2] that provably correlates to source code for all levels of
-compiler optimization.
+Coverage (MC/DC)[2] that provably correlates to source code for all levels
+of compiler optimization.
 
 The newly added kernel/llvm-cov/ directory complements the existing gcov
-implementation. Gcov works at the object code level which may better reflect
-actual execution. However, Gcov lacks the necessary information to correlate
-coverage measurement with source code location when compiler optimization
-level is non-zero (which is the default when building the kernel). In addition,
-gcov reports are occasionally ambiguous when attempting to compare with
-source code level developer intent.
+implementation. Gcov works at the object code level which may better
+reflect actual execution. However, Gcov lacks the necessary information to
+correlate coverage measurement with source code location when compiler
+optimization level is non-zero (which is the default when building the
+kernel). In addition, gcov reports are occasionally ambiguous when
+attempting to compare with source code level developer intent.
 
-In the following gcov example from drivers/firmware/dmi_scan.c, an expression
-with four conditions is reported to have six branch outcomes, which is not
-ideally informative in many safety related use cases, such as automotive,
-medical, and aerospace.
+In the following gcov example from drivers/firmware/dmi_scan.c, an
+expression with four conditions is reported to have six branch outcomes,
+which is not ideally informative in many safety related use cases, such as
+automotive, medical, and aerospace.
 
         5: 1068:	if (s == e || *e != '/' || !month || month > 12) {
 branch  0 taken 5 (fallthrough)
@@ -30,11 +30,11 @@ branch  4 taken 0 (fallthrough)
 branch  5 taken 5
 
 On the other hand, Clang's Source-based Code Coverage instruments at the
-compiler frontend which maintains an accurate mapping from coverage measurement
-to source code location. Coverage reports reflect exactly how the code is
-written regardless of optimization and can present advanced metrics like branch
-coverage and MC/DC in a clearer way. Coverage report for the same snippet by
-llvm-cov would look as follows:
+compiler frontend which maintains an accurate mapping from coverage
+measurement to source code location. Coverage reports reflect exactly how
+the code is written regardless of optimization and can present advanced
+metrics like branch coverage and MC/DC in a clearer way. Coverage report
+for the same snippet by llvm-cov would look as follows:
 
  1068|      5|	if (s == e || *e != '/' || !month || month > 12) {
   ------------------
@@ -73,51 +73,52 @@ MC/DC measurement for the compound logic decision at line 43.
    44|      5|				continue;
 
 As the results suggest, during the span of measurement, only condition C2
-(!msr[bit].test(bit, data)) is covered. That means C2 was evaluated to both true
-and false, and in those test vectors C2 affected the decision outcome
+(!msr[bit].test(bit, data)) is covered. That means C2 was evaluated to both
+true and false, and in those test vectors C2 affected the decision outcome
 independently. Therefore MC/DC for this decision is 1 out of 2 (50.00%).
 
-To do a full kernel measurement, instrument the kernel with LLVM_COV_KERNEL_MCDC
-enabled, and optionally set a LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS value (the
-default is six). Run the testsuites, and collect the raw profile data under
+To do a full kernel measurement, instrument the kernel with
+LLVM_COV_KERNEL_MCDC enabled, and optionally set a
+LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS value (the default is six). Run the
+testsuites, and collect the raw profile data under
 /sys/kernel/debug/llvm-cov/profraw. Such raw profile data can be merged and
 indexed, and used for generating coverage reports in various formats.
 
   $ cp /sys/kernel/debug/llvm-cov/profraw vmlinux.profraw
   $ llvm-profdata merge vmlinux.profraw -o vmlinux.profdata
-  $ llvm-cov show --show-mcdc --show-mcdc-summary                              \
-                  --format=text --use-color=false -output-dir=coverage_reports \
-                  -instr-profile vmlinux.profdata vmlinux
+  $ llvm-cov show --show-mcdc --show-mcdc-summary                         \
+             --format=text --use-color=false -output-dir=coverage_reports \
+             -instr-profile vmlinux.profdata vmlinux
 
-The first patch in this series enables Clang's Source-based Code Coverage in the
-kernel. The second patch disables instrumentation in the same areas that were
-disabled for kernel/gcov/. The third patch adds kernel configuration directives
-to enable MC/DC instrumentation.
+The first patch in this series enables Clang's Source-based Code Coverage
+in the kernel. The second patch disables instrumentation in the same areas
+that were disabled for kernel/gcov/. The third patch adds kernel
+configuration directives to enable MC/DC instrumentation.
 
-This work reuses code from a previous effort by Sami Tolvanen et al. [4]. Our
-aim is for source-based *code coverage* required for high assurance (MC/DC)
-while [4] focused more on performance optimization.
+This work reuses code from a previous effort by Sami Tolvanen et al. [4].
+Our aim is for source-based *code coverage* required for high assurance
+(MC/DC) while [4] focused more on performance optimization.
 
-This initial submission is restricted to x86-64. Support for other architectures
-would need a bit more Makefile & linker script modification. Informally we've
-confirmed that arm64 works and more are being tested.
+This initial submission is restricted to x86-64. Support for other
+architectures would need a bit more Makefile & linker script modification.
+Informally we've confirmed that arm64 works and more are being tested.
 
-Note that Source-based Code Coverage is Clang-specific and isn't compatible with
-Clang's gcov support in kernel/gcov/. Currently, kernel/gcov/ is not able to
-measure MC/DC without modifying CFLAGS_GCOV and it would face the same issues in
-terms of source correlation as gcov in general does.
+Note that Source-based Code Coverage is Clang-specific and isn't compatible
+with Clang's gcov support in kernel/gcov/. Currently, kernel/gcov/ is not
+able to measure MC/DC without modifying CFLAGS_GCOV and it would face the
+same issues in terms of source correlation as gcov in general does.
 
-Some demo and results can be found in [5]. We will talk about this patch series
-in the Refereed Track at LPC 2024 [6] and would appreciate the community's
-feedback.
+Some demo and results can be found in [5]. We will talk about this patch
+series in the Refereed Track at LPC 2024 [6] and would appreciate the
+community's feedback.
 
 Known Limitations:
 
 Kernel code with logical expressions exceeding
 LVM_COV_KERNEL_MCDC_MAX_CONDITIONS will produce a compiler warning.
 Expressions with up to 45 conditions are found in the Linux kernel source
-tree, but 44 seems to be the max value before the build fails due to
-kernel size. As of LLVM 19 the max number of conditions possible is 32767.
+tree, but 44 seems to be the max value before the build fails due to kernel
+size. As of LLVM 19 the max number of conditions possible is 32767.
 
 As of LLVM 19, certain expressions are still not covered, and will produce
 build warnings when they are encountered:
@@ -160,7 +161,7 @@ Wentao Zhang (3):
  drivers/firmware/efi/libstub/Makefile |   2 +
  include/asm-generic/vmlinux.lds.h     |  38 ++++
  kernel/Makefile                       |   1 +
- kernel/llvm-cov/Kconfig               |  50 +++++
+ kernel/llvm-cov/Kconfig               |  65 +++++++
  kernel/llvm-cov/Makefile              |   5 +
  kernel/llvm-cov/fs.c                  | 253 ++++++++++++++++++++++++++
  kernel/llvm-cov/llvm-cov.h            | 156 ++++++++++++++++
@@ -168,7 +169,7 @@ Wentao Zhang (3):
  scripts/Makefile.lib                  |  21 +++
  scripts/Makefile.modfinal             |   1 +
  scripts/mod/modpost.c                 |   2 +
- 22 files changed, 550 insertions(+)
+ 22 files changed, 565 insertions(+)
  create mode 100644 kernel/llvm-cov/Kconfig
  create mode 100644 kernel/llvm-cov/Makefile
  create mode 100644 kernel/llvm-cov/fs.c

--- a/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -27,13 +27,13 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  arch/x86/kernel/vmlinux.lds.S     |   2 +
  include/asm-generic/vmlinux.lds.h |  38 +++++
  kernel/Makefile                   |   1 +
- kernel/llvm-cov/Kconfig           |  30 ++++
+ kernel/llvm-cov/Kconfig           |  29 ++++
  kernel/llvm-cov/Makefile          |   5 +
  kernel/llvm-cov/fs.c              | 253 ++++++++++++++++++++++++++++++
  kernel/llvm-cov/llvm-cov.h        | 156 ++++++++++++++++++
  scripts/Makefile.lib              |  10 ++
  scripts/mod/modpost.c             |   2 +
- 12 files changed, 502 insertions(+)
+ 12 files changed, 501 insertions(+)
  create mode 100644 kernel/llvm-cov/Kconfig
  create mode 100644 kernel/llvm-cov/Makefile
  create mode 100644 kernel/llvm-cov/fs.c
@@ -153,10 +153,10 @@ index 3c13240dfc9f..773e6a9ee00a 100644
  
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
 new file mode 100644
-index 000000000000..b28090ba926b
+index 000000000000..505eba5bd23c
 --- /dev/null
 +++ b/kernel/llvm-cov/Kconfig
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,29 @@
 +# SPDX-License-Identifier: GPL-2.0-only
 +menu "Clang's source-based kernel coverage measurement (EXPERIMENTAL)"
 +
@@ -186,7 +186,6 @@ index 000000000000..b28090ba926b
 +	  profile.
 +
 +endmenu
-+
 diff --git a/kernel/llvm-cov/Makefile b/kernel/llvm-cov/Makefile
 new file mode 100644
 index 000000000000..a0f45e05f8fb

--- a/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -40,7 +40,7 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  create mode 100644 kernel/llvm-cov/llvm-cov.h
 
 diff --git a/Makefile b/Makefile
-index 68ebd6d6b..1750a2b7d 100644
+index 68ebd6d6b444..1750a2b7dfe8 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -737,6 +737,9 @@ endif # KBUILD_EXTMOD
@@ -54,7 +54,7 @@ index 68ebd6d6b..1750a2b7d 100644
  ifdef CONFIG_CC_IS_GCC
  CFLAGS_GCOV	+= -fno-tree-loop-im
 diff --git a/arch/Kconfig b/arch/Kconfig
-index 975dd22a2..0727265f6 100644
+index 975dd22a2dbd..0727265f677f 100644
 --- a/arch/Kconfig
 +++ b/arch/Kconfig
 @@ -1601,6 +1601,7 @@ config ARCH_HAS_KERNEL_FPU_SUPPORT
@@ -66,7 +66,7 @@ index 975dd22a2..0727265f6 100644
  source "scripts/gcc-plugins/Kconfig"
  
 diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index 007bab9f2..87a793b82 100644
+index 007bab9f2a0e..87a793b82bab 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
 @@ -85,6 +85,7 @@ config X86
@@ -78,7 +78,7 @@ index 007bab9f2..87a793b82 100644
  	select ARCH_HAS_MEM_ENCRYPT
  	select ARCH_HAS_MEMBARRIER_SYNC_CORE
 diff --git a/arch/x86/kernel/vmlinux.lds.S b/arch/x86/kernel/vmlinux.lds.S
-index 6e73403e8..904337722 100644
+index 6e73403e874f..90433772240a 100644
 --- a/arch/x86/kernel/vmlinux.lds.S
 +++ b/arch/x86/kernel/vmlinux.lds.S
 @@ -191,6 +191,8 @@ SECTIONS
@@ -91,7 +91,7 @@ index 6e73403e8..904337722 100644
  
  	. = ALIGN(PAGE_SIZE);
 diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
-index 1ae447931..770ff8469 100644
+index 1ae44793132a..770ff8469dcd 100644
 --- a/include/asm-generic/vmlinux.lds.h
 +++ b/include/asm-generic/vmlinux.lds.h
 @@ -334,6 +334,44 @@
@@ -140,7 +140,7 @@ index 1ae447931..770ff8469 100644
  	STRUCT_ALIGN();							\
  	__dtb_start = .;						\
 diff --git a/kernel/Makefile b/kernel/Makefile
-index 3c13240df..773e6a9ee 100644
+index 3c13240dfc9f..773e6a9ee00a 100644
 --- a/kernel/Makefile
 +++ b/kernel/Makefile
 @@ -117,6 +117,7 @@ obj-$(CONFIG_HAVE_STATIC_CALL) += static_call.o
@@ -153,7 +153,7 @@ index 3c13240df..773e6a9ee 100644
  
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
 new file mode 100644
-index 000000000..b28090ba9
+index 000000000000..b28090ba926b
 --- /dev/null
 +++ b/kernel/llvm-cov/Kconfig
 @@ -0,0 +1,30 @@
@@ -189,7 +189,7 @@ index 000000000..b28090ba9
 +
 diff --git a/kernel/llvm-cov/Makefile b/kernel/llvm-cov/Makefile
 new file mode 100644
-index 000000000..a0f45e05f
+index 000000000000..a0f45e05f8fb
 --- /dev/null
 +++ b/kernel/llvm-cov/Makefile
 @@ -0,0 +1,5 @@
@@ -201,7 +201,7 @@ index 000000000..a0f45e05f
 \ No newline at end of file
 diff --git a/kernel/llvm-cov/fs.c b/kernel/llvm-cov/fs.c
 new file mode 100644
-index 000000000..917ca50d0
+index 000000000000..917ca50d0496
 --- /dev/null
 +++ b/kernel/llvm-cov/fs.c
 @@ -0,0 +1,253 @@
@@ -461,7 +461,7 @@ index 000000000..917ca50d0
 \ No newline at end of file
 diff --git a/kernel/llvm-cov/llvm-cov.h b/kernel/llvm-cov/llvm-cov.h
 new file mode 100644
-index 000000000..4a91b3c8e
+index 000000000000..4a91b3c8ed72
 --- /dev/null
 +++ b/kernel/llvm-cov/llvm-cov.h
 @@ -0,0 +1,156 @@
@@ -623,7 +623,7 @@ index 000000000..4a91b3c8e
 +#endif /* _LLVM_COV_H */
 \ No newline at end of file
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index fe3668dc4..b9ceaee34 100644
+index fe3668dc4954..b9ceaee34b28 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -158,6 +158,16 @@ _c_flags += $(if $(patsubst n%,, \
@@ -644,7 +644,7 @@ index fe3668dc4..b9ceaee34 100644
  # Enable address sanitizer flags for kernel except some files or directories
  # we don't want to check (depends on variables KASAN_SANITIZE_obj.o, KASAN_SANITIZE)
 diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
-index d16d0ace2..836c2289b 100644
+index d16d0ace2775..836c2289b8d8 100644
 --- a/scripts/mod/modpost.c
 +++ b/scripts/mod/modpost.c
 @@ -743,6 +743,8 @@ static const char *const section_white_list[] =
@@ -657,5 +657,5 @@ index d16d0ace2..836c2289b 100644
  };
  
 -- 
-2.34.1
+2.45.2
 

--- a/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -200,7 +200,7 @@ index 000000000000..a0f45e05f8fb
 \ No newline at end of file
 diff --git a/kernel/llvm-cov/fs.c b/kernel/llvm-cov/fs.c
 new file mode 100644
-index 000000000000..917ca50d0496
+index 000000000000..c56f660a174e
 --- /dev/null
 +++ b/kernel/llvm-cov/fs.c
 @@ -0,0 +1,253 @@
@@ -457,10 +457,9 @@ index 000000000000..917ca50d0496
 +
 +module_init(llvm_cov_init);
 +module_exit(llvm_cov_exit);
-\ No newline at end of file
 diff --git a/kernel/llvm-cov/llvm-cov.h b/kernel/llvm-cov/llvm-cov.h
 new file mode 100644
-index 000000000000..4a91b3c8ed72
+index 000000000000..d9551a685756
 --- /dev/null
 +++ b/kernel/llvm-cov/llvm-cov.h
 @@ -0,0 +1,156 @@
@@ -620,7 +619,6 @@ index 000000000000..4a91b3c8ed72
 +}
 +
 +#endif /* _LLVM_COV_H */
-\ No newline at end of file
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
 index fe3668dc4954..b9ceaee34b28 100644
 --- a/scripts/Makefile.lib

--- a/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
+++ b/patches/v1.0/0001-llvm-cov-add-Clang-s-Source-based-Code-Coverage-supp.patch
@@ -4,9 +4,9 @@ Date: Wed, 14 Aug 2024 15:42:58 -0500
 Subject: [RFC PATCH 1/3] llvm-cov: add Clang's Source-based Code Coverage
  support
 
-This patch implements the debugfs entries for serializing profiles and
-resetting counters/bitmaps and adds Source-based Code Coverage flags and
-kconfig options.
+Implement debugfs entries for serializing profiles and resetting
+counters/bitmaps. Also adds Source-based Code Coverage flags and kconfig
+options.
 
 This work reuses a portion of code from a previous effort by Sami
 Tolvanen et al. [1], specifically its debugfs interface and the

--- a/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
+++ b/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
@@ -22,7 +22,7 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  10 files changed, 11 insertions(+)
 
 diff --git a/arch/x86/boot/Makefile b/arch/x86/boot/Makefile
-index 9cc0ff6e9..2cc2c55af 100644
+index 9cc0ff6e9067..2cc2c55af305 100644
 --- a/arch/x86/boot/Makefile
 +++ b/arch/x86/boot/Makefile
 @@ -57,6 +57,7 @@ KBUILD_AFLAGS	:= $(KBUILD_CFLAGS) -D__ASSEMBLY__
@@ -34,7 +34,7 @@ index 9cc0ff6e9..2cc2c55af 100644
  $(obj)/bzImage: asflags-y  := $(SVGA_MODE)
  
 diff --git a/arch/x86/boot/compressed/Makefile b/arch/x86/boot/compressed/Makefile
-index f2051644d..86c79c36d 100644
+index f2051644de94..86c79c36db2e 100644
 --- a/arch/x86/boot/compressed/Makefile
 +++ b/arch/x86/boot/compressed/Makefile
 @@ -43,6 +43,7 @@ KBUILD_CFLAGS += -D__DISABLE_EXPORTS
@@ -46,7 +46,7 @@ index f2051644d..86c79c36d 100644
  # sev.c indirectly includes inat-table.h which is generated during
  # compilation and stored in $(objtree). Add the directory to the includes so
 diff --git a/arch/x86/entry/vdso/Makefile b/arch/x86/entry/vdso/Makefile
-index c9216ac4f..d9587b3b6 100644
+index c9216ac4fb1e..d9587b3b6bf2 100644
 --- a/arch/x86/entry/vdso/Makefile
 +++ b/arch/x86/entry/vdso/Makefile
 @@ -156,6 +156,7 @@ quiet_cmd_vdso = VDSO    $@
@@ -58,7 +58,7 @@ index c9216ac4f..d9587b3b6 100644
  quiet_cmd_vdso_and_check = VDSO    $@
        cmd_vdso_and_check = $(cmd_vdso); $(cmd_vdso_check)
 diff --git a/arch/x86/platform/efi/Makefile b/arch/x86/platform/efi/Makefile
-index 500cab4a7..a07852e8f 100644
+index 500cab4a7f7c..a07852e8f3ae 100644
 --- a/arch/x86/platform/efi/Makefile
 +++ b/arch/x86/platform/efi/Makefile
 @@ -1,6 +1,7 @@
@@ -70,7 +70,7 @@ index 500cab4a7..a07852e8f 100644
  obj-$(CONFIG_EFI) 		+= memmap.o quirks.o efi.o efi_$(BITS).o \
  				   efi_stub_$(BITS).o
 diff --git a/arch/x86/purgatory/Makefile b/arch/x86/purgatory/Makefile
-index ebdfd7b84..b4e619114 100644
+index ebdfd7b84feb..b4e619114898 100644
 --- a/arch/x86/purgatory/Makefile
 +++ b/arch/x86/purgatory/Makefile
 @@ -28,6 +28,7 @@ PURGATORY_LDFLAGS := -e purgatory_start -z nodefaultlib
@@ -82,7 +82,7 @@ index ebdfd7b84..b4e619114 100644
  # These are adjustments to the compiler flags used for objects that
  # make up the standalone purgatory.ro
 diff --git a/arch/x86/realmode/rm/Makefile b/arch/x86/realmode/rm/Makefile
-index a0fb39abc..d36338bfa 100644
+index a0fb39abc5c8..d36338bfa2ce 100644
 --- a/arch/x86/realmode/rm/Makefile
 +++ b/arch/x86/realmode/rm/Makefile
 @@ -67,3 +67,4 @@ KBUILD_CFLAGS	:= $(REALMODE_CFLAGS) -D_SETUP -D_WAKEUP \
@@ -91,7 +91,7 @@ index a0fb39abc..d36338bfa 100644
  KBUILD_CFLAGS	+= -fno-asynchronous-unwind-tables
 +LLVM_COV_PROFILE := n
 diff --git a/arch/x86/um/vdso/Makefile b/arch/x86/um/vdso/Makefile
-index 6a77ea643..3ea2f5d12 100644
+index 6a77ea6434ff..3ea2f5d123fe 100644
 --- a/arch/x86/um/vdso/Makefile
 +++ b/arch/x86/um/vdso/Makefile
 @@ -60,3 +60,4 @@ quiet_cmd_vdso = VDSO    $@
@@ -100,7 +100,7 @@ index 6a77ea643..3ea2f5d12 100644
  VDSO_LDFLAGS = -fPIC -shared -Wl,--hash-style=sysv -z noexecstack
 +LLVM_COV_PROFILE := n
 diff --git a/drivers/firmware/efi/libstub/Makefile b/drivers/firmware/efi/libstub/Makefile
-index ed4e8ddbe..b8224ff29 100644
+index ed4e8ddbe76a..b8224ff291d9 100644
 --- a/drivers/firmware/efi/libstub/Makefile
 +++ b/drivers/firmware/efi/libstub/Makefile
 @@ -62,6 +62,8 @@ KBUILD_CFLAGS := $(filter-out $(CC_FLAGS_LTO), $(KBUILD_CFLAGS))
@@ -113,7 +113,7 @@ index ed4e8ddbe..b8224ff29 100644
  				   file.o mem.o random.o randomalloc.o pci.o \
  				   skip_spaces.o lib-cmdline.o lib-ctype.o \
 diff --git a/kernel/trace/Makefile b/kernel/trace/Makefile
-index 057cd975d..0293acc50 100644
+index 057cd975d014..0293acc50afa 100644
 --- a/kernel/trace/Makefile
 +++ b/kernel/trace/Makefile
 @@ -30,6 +30,7 @@ endif
@@ -125,7 +125,7 @@ index 057cd975d..0293acc50 100644
  # Functions in this file could be invoked from early interrupt
  # code and produce random code coverage.
 diff --git a/scripts/Makefile.modfinal b/scripts/Makefile.modfinal
-index 1fa98b5e9..4fc791fff 100644
+index 1fa98b5e952b..4fc791fff26c 100644
 --- a/scripts/Makefile.modfinal
 +++ b/scripts/Makefile.modfinal
 @@ -22,6 +22,7 @@ __modfinal: $(modules:%.o=%.ko)
@@ -137,5 +137,5 @@ index 1fa98b5e9..4fc791fff 100644
  
  quiet_cmd_cc_o_c = CC [M]  $@
 -- 
-2.34.1
+2.45.2
 

--- a/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
+++ b/patches/v1.0/0002-kbuild-llvm-cov-disable-instrumentation-in-odd-or-se.patch
@@ -4,7 +4,8 @@ Date: Wed, 14 Aug 2024 15:43:44 -0500
 Subject: [RFC PATCH 2/3] kbuild, llvm-cov: disable instrumentation in odd or
  sensitive code
 
-Skip the same set of files that were not instrumented by gcov either.
+Disable instrumentation in the same areas that were disabled for
+kernel/gcov/
 
 Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
 Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>

--- a/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
+++ b/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
@@ -29,7 +29,7 @@ Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
  3 files changed, 38 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 1750a2b7d..4aa263e5f 100644
+index 1750a2b7dfe8..4aa263e5f67f 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -740,6 +740,12 @@ all: vmlinux
@@ -46,7 +46,7 @@ index 1750a2b7d..4aa263e5f 100644
  ifdef CONFIG_CC_IS_GCC
  CFLAGS_GCOV	+= -fno-tree-loop-im
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
-index b28090ba9..d388a4adc 100644
+index b28090ba926b..d388a4adc6bc 100644
 --- a/kernel/llvm-cov/Kconfig
 +++ b/kernel/llvm-cov/Kconfig
 @@ -26,5 +26,26 @@ config LLVM_COV_KERNEL
@@ -77,7 +77,7 @@ index b28090ba9..d388a4adc 100644
  endmenu
  
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index b9ceaee34..b8dfad01c 100644
+index b9ceaee34b28..b8dfad01cb52 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -168,6 +168,17 @@ _c_flags += $(if $(patsubst n%,, \
@@ -99,5 +99,5 @@ index b9ceaee34..b8dfad01c 100644
  # Enable address sanitizer flags for kernel except some files or directories
  # we don't want to check (depends on variables KASAN_SANITIZE_obj.o, KASAN_SANITIZE)
 -- 
-2.34.1
+2.45.2
 

--- a/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
+++ b/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
@@ -6,7 +6,7 @@ Subject: [RFC PATCH 3/3] llvm-cov: add Clang's MC/DC support
 Add Clang flags and kconfig options for measuring the kernel's modified
 condition/decision coverage (MC/DC).
 
-With Clang >= 19, users can determine the max number of conditions in a
+As of Clang 19, users can determine the max number of conditions in a
 decision to measure via option LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS,
 which controls -fmcdc-max-conditions flag of Clang cc1 [1]. Since MC/DC
 implementation utilizes bitmaps to track the execution of test vectors,
@@ -18,7 +18,22 @@ otherwise the kernel image size limit will be exceeded. The largest
 decisions in kernel are contributed for example by macros checking
 CPUID.
 
+Code exceeding LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS will produce compiler
+warnings.
+
+As of LLVM 19, certain expressions are still not covered, and will produce
+build warnings when they are encountered:
+
+"[...] if a boolean expression is embedded in the nest of another boolean
+ expression but separated by a non-logical operator, this is also not
+ supported. For example, in x = (a && b && c && func(d && f)), the d && f
+ case starts a new boolean expression that is separated from the other
+ conditions by the operator func(). When this is encountered, a warning
+ will be generated and the boolean expression will not be
+ instrumented." [2]
+
 [1] https://discourse.llvm.org/t/rfc-coverage-new-algorithm-and-file-format-for-mc-dc/76798
+[2] https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#mc-dc-instrumentation
 
 Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
 Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>

--- a/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
+++ b/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
@@ -39,9 +39,9 @@ Signed-off-by: Wentao Zhang <wentaoz5@illinois.edu>
 Signed-off-by: Chuck Wolber <chuck.wolber@boeing.com>
 ---
  Makefile                |  6 ++++++
- kernel/llvm-cov/Kconfig | 21 +++++++++++++++++++++
+ kernel/llvm-cov/Kconfig | 36 ++++++++++++++++++++++++++++++++++++
  scripts/Makefile.lib    | 11 +++++++++++
- 3 files changed, 38 insertions(+)
+ 3 files changed, 53 insertions(+)
 
 diff --git a/Makefile b/Makefile
 index 1750a2b7dfe8..4aa263e5f67f 100644
@@ -61,10 +61,10 @@ index 1750a2b7dfe8..4aa263e5f67f 100644
  ifdef CONFIG_CC_IS_GCC
  CFLAGS_GCOV	+= -fno-tree-loop-im
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
-index 505eba5bd23c..e20fd887eaab 100644
+index 505eba5bd23c..40b6a4fd590e 100644
 --- a/kernel/llvm-cov/Kconfig
 +++ b/kernel/llvm-cov/Kconfig
-@@ -26,4 +26,25 @@ config LLVM_COV_KERNEL
+@@ -26,4 +26,40 @@ config LLVM_COV_KERNEL
  	  Note that the debugfs filesystem has to be mounted to access the raw
  	  profile.
  
@@ -73,10 +73,25 @@ index 505eba5bd23c..e20fd887eaab 100644
 +	depends on LLVM_COV_KERNEL
 +	depends on CLANG_VERSION >= 180000
 +	help
-+	  This option enables measuring kernel's modified condition/decision
-+	  coverage (MC/DC) with Clang's Source-based Code Coverage.
++	  This option enables modified condition/decision coverage (MC/DC)
++	  code coverage instrumentation.
 +
 +	  If unsure, say N.
++
++	  This will add Clang's Source-based Code Coverage MC/DC
++	  instrumentation to your kernel. As of LLVM 19, certain expressions
++	  are still not covered, and will produce build warnings when they are
++	  encountered.
++
++	  "[...] if a boolean expression is embedded in the nest of another
++	   boolean expression but separated by a non-logical operator, this is
++	   also not supported. For example, in
++	   x = (a && b && c && func(d && f)), the d && f case starts a new
++	   boolean expression that is separated from the other conditions by the
++	   operator func(). When this is encountered, a warning will be
++	   generated and the boolean expression will not be instrumented."
++
++	   https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#mc-dc-instrumentation
 +
 +config LLVM_COV_KERNEL_MCDC_MAX_CONDITIONS
 +	int "Maximum number of conditions in a decision to instrument"

--- a/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
+++ b/patches/v1.0/0003-llvm-cov-add-Clang-s-MC-DC-support.patch
@@ -61,10 +61,10 @@ index 1750a2b7dfe8..4aa263e5f67f 100644
  ifdef CONFIG_CC_IS_GCC
  CFLAGS_GCOV	+= -fno-tree-loop-im
 diff --git a/kernel/llvm-cov/Kconfig b/kernel/llvm-cov/Kconfig
-index b28090ba926b..d388a4adc6bc 100644
+index 505eba5bd23c..e20fd887eaab 100644
 --- a/kernel/llvm-cov/Kconfig
 +++ b/kernel/llvm-cov/Kconfig
-@@ -26,5 +26,26 @@ config LLVM_COV_KERNEL
+@@ -26,4 +26,25 @@ config LLVM_COV_KERNEL
  	  Note that the debugfs filesystem has to be mounted to access the raw
  	  profile.
  
@@ -90,7 +90,6 @@ index b28090ba926b..d388a4adc6bc 100644
 +	  produce warnings and will not be instrumented.
 +
  endmenu
- 
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
 index b9ceaee34b28..b8dfad01cb52 100644
 --- a/scripts/Makefile.lib


### PR DESCRIPTION
Prepare the patches for upstream submission.

- Update formatted patch version from git 2.34.1 to git 2.45.2. This is generally superficial, but a small defect in the cover letter patch was fixed in the process.
- Added additional detail to the cover letter and propagated that wording where relevant to the individual patches.
- Fix a defect in patches 0001 and 0003 that triggered warnings when the patch was applied.
- Address most warnings produced by the kernel utility `scripts/checkpatch.pl`.

Additional detail can be found in the individual commit messages.